### PR TITLE
Add database rebalance script

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,14 @@
+# Clubhall Bot
+
+Utility bot for Discord.
+
+## Database Rebalancing
+
+A maintenance script lives in `scripts/rebalance_db.py` to shrink coin totals and stats.
+Run it with:
+
+```bash
+python scripts/rebalance_db.py
+```
+
+**Important:** back up your `users.db` database before running the script.

--- a/scripts/rebalance_db.py
+++ b/scripts/rebalance_db.py
@@ -1,0 +1,34 @@
+import sqlite3
+from config import DB_PATH
+
+SCALE_COINS = 1_000_000
+SCALE_STATS = 10
+
+
+def rebalance():
+    conn = sqlite3.connect(DB_PATH)
+    cursor = conn.cursor()
+    cursor.execute(
+        "SELECT user_id, money, stat_points, intelligence, strength, stealth FROM users"
+    )
+    for user_id, money, sp, intel, stren, stealth in cursor.fetchall():
+        cursor.execute(
+            "UPDATE users SET money=?, stat_points=?, intelligence=?, strength=?, stealth=? WHERE user_id=?",
+            (
+                money // SCALE_COINS,
+                sp // SCALE_STATS,
+                max(1, intel // SCALE_STATS),
+                max(1, stren // SCALE_STATS),
+                max(1, stealth // SCALE_STATS),
+                user_id,
+            ),
+        )
+
+    cursor.execute("UPDATE server SET max_coins = max_coins / ?", (SCALE_COINS,))
+    conn.commit()
+    conn.close()
+
+
+if __name__ == "__main__":
+    rebalance()
+    print("Database rebalanced.")


### PR DESCRIPTION
## Summary
- add `scripts/rebalance_db.py` to scale down user coin and stat values
- document how to run the script in new `README.md`

## Testing
- `python -m py_compile scripts/rebalance_db.py`


------
https://chatgpt.com/codex/tasks/task_e_685fd5eaed00832796b4e01020001256