### PR TITLE
Add path fix for DB rebalance script

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,14 @@
+# Clubhall Bot
+
+Utility bot for Discord.
+
+## Database Rebalancing
+
+A maintenance script lives in `scripts/rebalance_db.py` to shrink coin totals and stats.
+Run it from the project root with:
+
+```bash
+python scripts/rebalance_db.py
+```
+
+**Important:** back up your `users.db` database before running the script.

--- a/scripts/rebalance_db.py
+++ b/scripts/rebalance_db.py
@@ -1,0 +1,42 @@
+import sqlite3
+import sys
+from pathlib import Path
+
+# ensure project root is on the Python path when running as a script
+ROOT = Path(__file__).resolve().parent.parent
+if str(ROOT) not in sys.path:
+    sys.path.append(str(ROOT))
+
+from config import DB_PATH
+
+SCALE_COINS = 1_000_000
+SCALE_STATS = 10
+
+
+def rebalance():
+    conn = sqlite3.connect(DB_PATH)
+    cursor = conn.cursor()
+    cursor.execute(
+        "SELECT user_id, money, stat_points, intelligence, strength, stealth FROM users"
+    )
+    for user_id, money, sp, intel, stren, stealth in cursor.fetchall():
+        cursor.execute(
+            "UPDATE users SET money=?, stat_points=?, intelligence=?, strength=?, stealth=? WHERE user_id=?",
+            (
+                money // SCALE_COINS,
+                sp // SCALE_STATS,
+                max(1, intel // SCALE_STATS),
+                max(1, stren // SCALE_STATS),
+                max(1, stealth // SCALE_STATS),
+                user_id,
+            ),
+        )
+
+    cursor.execute("UPDATE server SET max_coins = max_coins / ?", (SCALE_COINS,))
+    conn.commit()
+    conn.close()
+
+
+if __name__ == "__main__":
+    rebalance()
+    print("Database rebalanced.")


### PR DESCRIPTION
## Summary
- fix import path in `rebalance_db.py` so it can be run directly
- clarify README instructions to run the script from the project root

## Testing
- `python -m py_compile scripts/rebalance_db.py`
- `python scripts/rebalance_db.py` *(fails: no such table: users)*

------
https://chatgpt.com/codex/tasks/task_e_685fd5eaed00832796b4e01020001256