### PR TITLE
Add anime title rolling command

### DIFF
--- a/commands/economy_commands.py
+++ b/commands/economy_commands.py
@@ -46,6 +46,8 @@ from db.DBHelper import (
     set_last_claim,
     get_timestamp,
     set_timestamp,
+    get_anime_title,
+    set_anime_title,
 )
 from utils import has_role
 
@@ -632,6 +634,178 @@ def setup(bot: commands.Bot):
         )
 
     @bot.tree.command(
+        name="animetitle",
+        description=(
+            "Roll a random anime character title. Rerolls cost 10% of your"
+            " coins (minimum 500k)."
+        ),
+    )
+    async def animetitle(interaction: discord.Interaction):
+        uid = str(interaction.user.id)
+        register_user(uid, interaction.user.display_name)
+        guild = interaction.guild
+
+        titles = [
+            "The Black Swordsman (Guts - Berserk)",
+            "Pirate King (Monkey D. Luffy - One Piece)",
+            "Hokage (Naruto Uzumaki - Naruto)",
+            "Symbol of Peace (All Might - My Hero Academia)",
+            "Titan Slayer (Mikasa Ackerman - Attack on Titan)",
+            "Fullmetal Alchemist (Edward Elric - FMA)",
+            "Soul Reaper (Ichigo Kurosaki - Bleach)",
+            "Dragon of the Darkness Flame (Hiei - Yu Yu Hakusho)",
+            "King of Games (Yugi Muto - Yu-Gi-Oh!)",
+            "Master of the Cursed Energy (Satoru Gojo - Jujutsu Kaisen)",
+            "Ghoul Investigator (Ken Kaneki - Tokyo Ghoul)",
+            "Flame Hashira (Kyojuro Rengoku - Demon Slayer)",
+            "Spirit Detective (Yusuke Urameshi - Yu Yu Hakusho)",
+            "Seventh Hokage (Naruto Uzumaki - Naruto)",
+            "Blue Exorcist (Rin Okumura - Blue Exorcist)",
+            "The Railgun (Mikoto Misaka - Index)",
+            "Toon Sorcerer (Asta - Black Clover)",
+            "Goddess of Death (Ryuk - Death Note)",
+            "Ultra Instinct (Goku - Dragon Ball)",
+            "Straw Hat (Monkey D. Luffy - One Piece)",
+            "Red-Haired Emperor (Shanks - One Piece)",
+            "Flame Alchemist (Roy Mustang - FMA)",
+            "Blue-Haired Swordsman (Kirito - SAO)",
+            "Magical Girl (Madoka Kaname - Madoka Magica)",
+            "Vampire Queen (Seras Victoria - Hellsing)",
+            "Wandering Samurai (Kenshin Himura - Rurouni Kenshin)",
+            "Esper Ace (Tatsumaki - One Punch Man)",
+            "Cyborg Hero (Genos - One Punch Man)",
+            "Gurren Pilot (Simon - Gurren Lagann)",
+            "Absolute Sword (Yuuki - SAO)",
+            "Ninja President (Boruto - Naruto)",
+            "Blue Flame Dragon (Shoto Todoroki - MHA)",
+            "White Reaper (Toshiro Hitsugaya - Bleach)",
+            "Lightning Beast (Killua Zoldyck - Hunter x Hunter)",
+            "Chimera King (Meruem - Hunter x Hunter)",
+            "Fire Fist (Portgas D. Ace - One Piece)",
+            "Copy Ninja (Kakashi Hatake - Naruto)",
+            "Quinx Leader (Haise Sasaki - Tokyo Ghoul:re)",
+            "Shadow Monarch (Sung Jin-Woo - Solo Leveling)",
+            "Red Comet (Char Aznable - Gundam)",
+            "Demon Queen (Milim Nava - Slime)",
+            "The Strongest Hero (Saitama - One Punch Man)",
+            "Dragon Maid (Tohru - Miss Kobayashi's Dragon Maid)",
+            "Card Master (Sakura Kinomoto - Cardcaptor Sakura)",
+            "Angel of Death (Lucy - Elfen Lied)",
+            "Sword Saint (Saber - Fate)",
+            "Ice Devil (Gray Fullbuster - Fairy Tail)",
+            "Black Clover Wizard (Asta - Black Clover)",
+            "Violet Evergarden (Violet - Violet Evergarden)",
+            "Magic Emperor (Yami Sukehiro - Black Clover)",
+            "Chunin Prodigy (Shikamaru Nara - Naruto)",
+            "Water Pillar (Giyu Tomioka - Demon Slayer)",
+            "Great Saiyaman (Gohan - Dragon Ball) ",
+            "Death Scythe (Maka Albarn - Soul Eater)",
+            "Goddess Reborn (Aqua - Konosuba)",
+            "Supreme Kai (Shin - Dragon Ball Z)",
+            "Pro-Hero Rookie (Izuku Midoriya - MHA)",
+            "Demon Barber (Grell Sutcliff - Black Butler)",
+            "Lord Frieza (Frieza - Dragon Ball Z)",
+            "Time Wizard (Jotaro Kujo - JoJo)",
+            "Galaxy Police (Kiyone - Tenchi Muyo)",
+            "The Violet Devil (Shinobu Kocho - Demon Slayer)",
+            "Lucky Master (Rintarou Okabe - Steins;Gate)",
+            "Devil Hunter (Denji - Chainsaw Man)",
+            "Magic Knight (Lelouch Lamperouge - Code Geass)",
+            "Black Reaper (Hei - Darker than Black)",
+            "Metal Alchemist (Alphonse Elric - FMA)",
+            "Pink Shinobi (Sakura Haruno - Naruto)",
+            "Ghost Princess (Perona - One Piece)",
+            "Spirit Gunner (Yusuke Urameshi - Yu Yu Hakusho)",
+            "Speedwagon Foundation (Robert E.O. Speedwagon - JoJo)",
+            "Hero of Justice (Emiya Shirou - Fate/Stay Night)",
+            "Maiden of Rebirth (Neon Genesis Evangelion - Rei Ayanami)",
+            "Trickster Mage (Megumin - Konosuba)",
+            "Silent Swordsman (Zoro - One Piece)",
+            "Flower Hashira (Shinobu Kocho - Demon Slayer)",
+            "Black Bull Captain (Yami Sukehiro - Black Clover)",
+            "Fairy Queen (Titania Erza - Fairy Tail)",
+            "Kitsune Illusionist (Kurama - Naruto)",
+            "Wing Hero (Hawks - MHA)",
+            "Red Riot (Eijiro Kirishima - MHA)",
+            "Metal Knight (Genos - One Punch Man)",
+            "Storm Dragon (Veldora - Slime)",
+            "Goddess of War (Valkyrie Brunhilde - Record of Ragnarok)",
+            "Demon Sister (Satella - Re:Zero)",
+            "Gun Gale Shooter (Sinon - SAO)",
+            "Railgun Ace (Accelerator - Index)",
+            "Moon Princess (Usagi Tsukino - Sailor Moon)",
+            "Genius Hacker (Kaminari Denki - MHA)",
+            "Shinigami Prince (Sebastian Michaelis - Black Butler)",
+            "Sun Breather (Tanjiro Kamado - Demon Slayer)",
+            "Psycho Soldier (Mob - Mob Psycho 100)",
+            "Spirit Fox (Shippo - Inuyasha)",
+            "Homunculus Survivor (Riza Hawkeye - FMA)",
+            "Chaos Swordsman (Inosuke Hashibira - Demon Slayer)",
+            "Wind Master (Kazuma - Konosuba)",
+            "Queen's Blade (Esdeath - Akame ga Kill!)",
+            "Golem Rider (Noelle Silva - Black Clover)",
+            "The Other One (Rem - Re:Zero)",
+            "Zero's Successor (Kamijo Touma - Index)",
+            "Machine God (Diane - Seven Deadly Sins)",
+            "Shield Hero (Naofumi Iwatani - Shield Hero)",
+            "Stone World Genius (Senku Ishigami - Dr. Stone)",
+            "Night Raid Assassin (Akame - Akame ga Kill!)",
+            "Pudding Princess (Pudding - One Piece)",
+            "Spiral Warrior (Kamina - Gurren Lagann)",
+            "Endless Swords (Archer - Fate)",
+            "Ice Queen (Esdeath - Akame ga Kill!)",
+            "Dreaming Detective (Conan Edogawa - Detective Conan)",
+            "NerveGear Survivor (Asuna - SAO)",
+            "Goddess of Victory (Bishamon - Noragami)",
+            "Martial Artist (Baki Hanma - Baki)",
+            "Netherworld Butler (Sebastian - Black Butler)",
+            "Alchemist Hunter (Scar - FMA)",
+            "Holy Maiden (Jeanne d'Arc - Fate/Apocrypha)",
+            "Magic Swordsman (Ragna - Ragna Crimson)",
+            "The Great Wizard (Merlin - Seven Deadly Sins)",
+            "Saiyan Prince (Vegeta - Dragon Ball Z)",
+            "Crystal Sorceress (Juvia Lockser - Fairy Tail)",
+            "Revived Hero (Meliodas - Seven Deadly Sins)",
+        ]
+
+        current = get_anime_title(uid)
+        balance = get_money(uid)
+
+        if current:
+            cost = max(int(balance * 0.1), 500_000)
+            if balance < cost:
+                await interaction.response.send_message(
+                    f"❌ You need {cost} coins to change your title.",
+                    ephemeral=True,
+                )
+                return
+            set_money(uid, balance - cost)
+            role = discord.utils.get(guild.roles, name=current)
+            if role:
+                try:
+                    await interaction.user.remove_roles(role, reason="Anime title reroll")
+                except discord.Forbidden:
+                    pass
+
+        title = choice(titles)
+        role = discord.utils.get(guild.roles, name=title)
+        if role is None:
+            try:
+                role = await guild.create_role(name=title, reason="Anime title reward")
+            except discord.Forbidden:
+                role = None
+        if role:
+            try:
+                await interaction.user.add_roles(role, reason="Anime title reward")
+            except discord.Forbidden:
+                pass
+        set_anime_title(uid, title)
+
+        await interaction.response.send_message(
+            f"{interaction.user.display_name} received the title **{title}**!"
+        )
+
+    @bot.tree.command(
         name="gamble", description="Gamble your coins for a chance to win more!"
     )
     async def gamble(interaction: discord.Interaction, amount: int):
@@ -767,6 +941,7 @@ def setup(bot: commands.Bot):
         weekly,
         daily,
         superpower,
+        animetitle,
         gamble,
         casino,
         duel,

--- a/db/DBHelper.py
+++ b/db/DBHelper.py
@@ -251,6 +251,24 @@ def delete_custom_role(user_id: str):
     _execute("DELETE FROM custom_roles WHERE user_id = ?", (user_id,))
 
 
+# ---------- anime title helpers ----------
+
+def get_anime_title(user_id: str):
+    row = _fetchone("SELECT role_name FROM anime_titles WHERE user_id = ?", (user_id,))
+    return row[0] if row else None
+
+
+def set_anime_title(user_id: str, role_name: str):
+    _execute(
+        "INSERT OR REPLACE INTO anime_titles (user_id, role_name) VALUES (?, ?)",
+        (user_id, role_name),
+    )
+
+
+def delete_anime_title(user_id: str):
+    _execute("DELETE FROM anime_titles WHERE user_id = ?", (user_id,))
+
+
 # ---------- giveaway helpers ----------
 
 def create_giveaway(

--- a/db/initializeDB.py
+++ b/db/initializeDB.py
@@ -95,6 +95,15 @@ def init_db():
 
     cursor.execute(
         """
+    CREATE TABLE IF NOT EXISTS anime_titles (
+        user_id TEXT PRIMARY KEY,
+        role_name TEXT NOT NULL
+    )
+    """
+    )
+
+    cursor.execute(
+        """
         CREATE TABLE IF NOT EXISTS dates (
             user_id TEXT PRIMARY KEY,
             registered_date TEXT


### PR DESCRIPTION
## Summary
- add `anime_titles` table
- support setting/clearing anime title data in DB helper
- create `/animetitle` command to roll anime character titles

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6868e8fad1408327b4e2f2b38943ddb6