### PR TITLE
Add anti nuke system

### DIFF
--- a/anti_nuke.py
+++ b/anti_nuke.py
@@ -1,0 +1,177 @@
+import discord
+from discord.ext import commands
+from datetime import datetime, timedelta
+from typing import Dict, List, Optional
+from db.DBHelper import (
+    get_anti_nuke_setting,
+    get_safe_users,
+    get_safe_roles,
+    get_anti_nuke_log_channel,
+)
+
+OWNER_ID = 756537363509018736
+
+ACTION_WINDOW = 15  # seconds
+
+action_history: Dict[str, Dict[int, List[float]]] = {}
+
+CATEGORIES = {
+    "delete_roles": discord.AuditLogAction.role_delete,
+    "add_roles": discord.AuditLogAction.role_create,
+    "kick": discord.AuditLogAction.kick,
+    "ban": discord.AuditLogAction.ban,
+    "delete_channels": discord.AuditLogAction.channel_delete,
+    "webhook": discord.AuditLogAction.webhook_create,
+    "anti_mention": None,
+}
+
+
+async def punish(member: discord.Member, punishment: str, duration: Optional[int]) -> None:
+    try:
+        if punishment == "timeout":
+            if duration is None:
+                duration = 60
+            until = discord.utils.utcnow() + timedelta(seconds=duration)
+            await member.timeout(until, reason="Anti-nuke")
+        elif punishment == "strip":
+            roles = [r for r in member.roles if not r.is_default()]
+            if roles:
+                await member.remove_roles(*roles, reason="Anti-nuke")
+        elif punishment == "kick":
+            await member.kick(reason="Anti-nuke")
+        elif punishment == "ban":
+            await member.ban(reason="Anti-nuke")
+    except Exception:
+        pass
+
+
+async def log_action(member: discord.Member, category: str, punishment: str, duration: Optional[int]) -> None:
+    cid = get_anti_nuke_log_channel()
+    if not cid:
+        return
+    channel = member.guild.get_channel(cid)
+    if channel:
+        info = f"{punishment}"
+        if punishment == "timeout" and duration:
+            info += f" {duration}s"
+        await channel.send(
+            f"<@{OWNER_ID}> {member.mention} triggered **{category}** - {info}"
+        )
+
+
+async def handle_event(guild: discord.Guild, user: Optional[discord.Member], category: str):
+    setting = get_anti_nuke_setting(category)
+    if not setting:
+        return
+    enabled, threshold, punishment, duration = setting
+    if not enabled:
+        return
+    uid = user.id if user else None
+    if uid is None:
+        return
+    if uid in get_safe_users():
+        return
+    safe_roles = set(get_safe_roles())
+    if any(r.id in safe_roles for r in user.roles):
+        return
+    hist = action_history.setdefault(category, {}).setdefault(uid, [])
+    now = datetime.utcnow().timestamp()
+    hist = [t for t in hist if now - t <= ACTION_WINDOW]
+    hist.append(now)
+    action_history[category][uid] = hist
+    if len(hist) >= threshold:
+        await punish(user, punishment, duration)
+        await log_action(user, category, punishment, duration)
+        action_history[category][uid] = []
+
+
+async def on_message(message: discord.Message):
+    if message.author.bot or message.webhook_id:
+        return
+    setting = get_anti_nuke_setting("anti_mention")
+    if not setting:
+        return
+    enabled, threshold, punishment, duration = setting
+    if not enabled:
+        return
+    mention_count = len(message.mentions)
+    mention_count += message.content.count("@here")
+    mention_count += message.content.count("@everyone")
+    if mention_count >= threshold:
+        await punish(message.author, punishment, duration)
+        await log_action(message.author, "anti_mention", punishment, duration)
+
+
+async def on_channel_delete(channel: discord.abc.GuildChannel):
+    guild = channel.guild
+    entry = None
+    async for e in guild.audit_logs(limit=1, action=discord.AuditLogAction.channel_delete):
+        entry = e
+        break
+    if entry and (datetime.utcnow() - entry.created_at).total_seconds() < ACTION_WINDOW:
+        member = guild.get_member(entry.user.id)
+        if member:
+            await handle_event(guild, member, "delete_channels")
+
+
+async def on_role_delete(role: discord.Role):
+    guild = role.guild
+    entry = None
+    async for e in guild.audit_logs(limit=1, action=discord.AuditLogAction.role_delete):
+        entry = e
+        break
+    if entry and (datetime.utcnow() - entry.created_at).total_seconds() < ACTION_WINDOW:
+        member = guild.get_member(entry.user.id)
+        if member:
+            await handle_event(guild, member, "delete_roles")
+
+
+async def on_role_create(role: discord.Role):
+    guild = role.guild
+    entry = None
+    async for e in guild.audit_logs(limit=1, action=discord.AuditLogAction.role_create):
+        entry = e
+        break
+    if entry and (datetime.utcnow() - entry.created_at).total_seconds() < ACTION_WINDOW:
+        member = guild.get_member(entry.user.id)
+        if member:
+            await handle_event(guild, member, "add_roles")
+
+
+async def on_member_remove(member: discord.Member):
+    guild = member.guild
+    async for e in guild.audit_logs(limit=1, action=discord.AuditLogAction.kick):
+        if e.target.id == member.id and (datetime.utcnow() - e.created_at).total_seconds() < ACTION_WINDOW:
+            actor = guild.get_member(e.user.id)
+            if actor:
+                await handle_event(guild, actor, "kick")
+            return
+
+
+async def on_member_ban(guild: discord.Guild, user: discord.User):
+    async for e in guild.audit_logs(limit=1, action=discord.AuditLogAction.ban):
+        if e.target.id == user.id and (datetime.utcnow() - e.created_at).total_seconds() < ACTION_WINDOW:
+            actor = guild.get_member(e.user.id)
+            if actor:
+                await handle_event(guild, actor, "ban")
+            return
+
+
+async def on_webhooks_update(channel: discord.abc.GuildChannel):
+    guild = channel.guild
+    async for e in guild.audit_logs(limit=1, action=discord.AuditLogAction.webhook_create):
+        if (datetime.utcnow() - e.created_at).total_seconds() < ACTION_WINDOW:
+            member = guild.get_member(e.user.id)
+            if member:
+                await handle_event(guild, member, "webhook")
+            break
+
+
+def setup(bot: commands.Bot):
+    bot.add_listener(on_channel_delete, name="on_guild_channel_delete")
+    bot.add_listener(on_role_delete, name="on_guild_role_delete")
+    bot.add_listener(on_role_create, name="on_guild_role_create")
+    bot.add_listener(on_member_remove, name="on_member_remove")
+    bot.add_listener(on_member_ban, name="on_member_ban")
+    bot.add_listener(on_webhooks_update, name="on_webhooks_update")
+    bot.add_listener(on_message, name="on_message")

--- a/bot.py
+++ b/bot.py
@@ -8,7 +8,9 @@ from commands.economy_commands import setup as setup_economy
 from commands.stats_commands import setup as setup_stats
 from commands.action_commands import setup as setup_action
 from commands.admin_commands import setup as setup_admin
+from commands.antinuke_commands import setup as setup_antinuke
 import events
+import anti_nuke
 
 
 intents = discord.Intents.default()
@@ -24,7 +26,9 @@ setup_economy(bot)
 setup_stats(bot, events.rod_shop)
 setup_action(bot)
 setup_admin(bot)
+setup_antinuke(bot)
 events.setup(bot, lowercase_locked)
+anti_nuke.setup(bot)
 
 with open("code.txt", "r") as file:
     TOKEN = file.read().strip()

--- a/commands/antinuke_commands.py
+++ b/commands/antinuke_commands.py
@@ -1,0 +1,118 @@
+import discord
+from discord import app_commands
+from discord.ext import commands
+from typing import Optional
+from utils import parse_duration
+from db.DBHelper import (
+    set_anti_nuke_setting,
+    get_anti_nuke_setting,
+    add_safe_user,
+    remove_safe_user,
+    get_safe_users,
+    add_safe_role,
+    remove_safe_role,
+    get_safe_roles,
+    set_anti_nuke_log_channel,
+    get_anti_nuke_log_channel,
+)
+
+OWNER_ID = 756537363509018736
+
+CATEGORIES = [
+    "delete_roles",
+    "add_roles",
+    "kick",
+    "ban",
+    "delete_channels",
+    "anti_mention",
+    "webhook",
+]
+
+
+def setup(bot: commands.Bot):
+    @bot.tree.command(name="antinukeconfig", description="Configure anti nuke category")
+    @app_commands.describe(
+        category="Category",
+        threshold="Actions before trigger",
+        punishment="timeout/strip/kick/ban",
+        duration="Timeout duration (e.g. 60s, 5m)",
+        enabled="Enable protection",
+    )
+    async def antinukeconfig(
+        interaction: discord.Interaction,
+        category: str,
+        threshold: int,
+        punishment: str,
+        duration: Optional[str],
+        enabled: bool,
+    ):
+        if interaction.user.id != OWNER_ID:
+            await interaction.response.send_message("No permission.", ephemeral=True)
+            return
+        if category not in CATEGORIES:
+            await interaction.response.send_message("Invalid category.", ephemeral=True)
+            return
+        dur_s = parse_duration(duration) if duration else None
+        set_anti_nuke_setting(category, int(enabled), threshold, punishment, dur_s)
+        await interaction.response.send_message("Saved.", ephemeral=True)
+
+    @bot.tree.command(name="antinukeignoreuser", description="Toggle safe user")
+    async def antinukeignoreuser(interaction: discord.Interaction, user: discord.Member):
+        if interaction.user.id != OWNER_ID:
+            await interaction.response.send_message("No permission.", ephemeral=True)
+            return
+        if user.id in get_safe_users():
+            remove_safe_user(user.id)
+            await interaction.response.send_message("User removed from safe list.", ephemeral=True)
+        else:
+            add_safe_user(user.id)
+            await interaction.response.send_message("User added to safe list.", ephemeral=True)
+
+    @bot.tree.command(name="antinukeignorerole", description="Toggle safe role")
+    async def antinukeignorerole(interaction: discord.Interaction, role: discord.Role):
+        if interaction.user.id != OWNER_ID:
+            await interaction.response.send_message("No permission.", ephemeral=True)
+            return
+        if role.id in get_safe_roles():
+            remove_safe_role(role.id)
+            await interaction.response.send_message("Role removed from safe list.", ephemeral=True)
+        else:
+            add_safe_role(role.id)
+            await interaction.response.send_message("Role added to safe list.", ephemeral=True)
+
+    @bot.tree.command(name="antinukelog", description="Set anti nuke log channel")
+    async def antinukelog(interaction: discord.Interaction, channel: discord.TextChannel):
+        if interaction.user.id != OWNER_ID:
+            await interaction.response.send_message("No permission.", ephemeral=True)
+            return
+        set_anti_nuke_log_channel(channel.id)
+        await interaction.response.send_message(
+            f"Log channel set to {channel.mention}", ephemeral=True
+        )
+
+    @bot.tree.command(name="antinukesettings", description="Show anti nuke configuration")
+    async def antinukesettings(interaction: discord.Interaction):
+        if interaction.user.id != OWNER_ID:
+            await interaction.response.send_message("No permission.", ephemeral=True)
+            return
+        lines = []
+        for cat in CATEGORIES:
+            setting = get_anti_nuke_setting(cat)
+            if setting:
+                en, th, p, dur = setting
+                desc = f"on" if en else "off"
+                desc += f", threshold={th}, punishment={p}"
+                if p == "timeout" and dur:
+                    desc += f" {dur}s"
+            else:
+                desc = "not set"
+            lines.append(f"**{cat}**: {desc}")
+
+        users = [f"<@{u}>" for u in get_safe_users()] or ["None"]
+        roles = [f"<@&{r}>" for r in get_safe_roles()] or ["None"]
+        cid = get_anti_nuke_log_channel()
+        log_line = f"<#{cid}>" if cid else "None"
+        lines.append(f"Safe users: {', '.join(users)}")
+        lines.append(f"Safe roles: {', '.join(roles)}")
+        lines.append(f"Log channel: {log_line}")
+        await interaction.response.send_message("\n".join(lines), ephemeral=True)

--- a/db/initializeDB.py
+++ b/db/initializeDB.py
@@ -132,6 +132,42 @@ def init_db():
         """
     )
 
+    cursor.execute(
+        """
+        CREATE TABLE IF NOT EXISTS anti_nuke_settings (
+            category TEXT PRIMARY KEY,
+            enabled INTEGER DEFAULT 0,
+            threshold INTEGER DEFAULT 1,
+            punishment TEXT DEFAULT 'kick',
+            duration INTEGER
+        )
+        """
+    )
+
+    cursor.execute(
+        """
+        CREATE TABLE IF NOT EXISTS anti_nuke_safe_users (
+            user_id TEXT PRIMARY KEY
+        )
+        """
+    )
+
+    cursor.execute(
+        """
+        CREATE TABLE IF NOT EXISTS anti_nuke_safe_roles (
+            role_id TEXT PRIMARY KEY
+        )
+        """
+    )
+
+    cursor.execute(
+        """
+        CREATE TABLE IF NOT EXISTS anti_nuke_log_channel (
+            channel_id TEXT PRIMARY KEY
+        )
+        """
+    )
+
     cursor.execute("PRAGMA table_info(users)")
     existing = {col[1] for col in cursor.fetchall()}
     for col, default in [


### PR DESCRIPTION
## Summary
- add anti-nuke database tables and helper functions
- implement anti-nuke monitoring events and punishments
- provide slash commands to configure anti-nuke settings
- wire anti-nuke system into bot startup
- allow setting a log channel and viewing configuration
- adjust type hints for better Python compatibility

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_687d62e37a80832783104a624b29c7af