### PR TITLE
Add admin-only test command

### DIFF
--- a/commands/admin_commands.py
+++ b/commands/admin_commands.py
@@ -1,4 +1,7 @@
 import asyncio
+import inspect
+import io
+
 import discord
 from discord import app_commands
 from discord.ext import commands
@@ -31,10 +34,71 @@ from db.DBHelper import (
 )
 from utils import has_role, get_channel_webhook, parse_duration
 
+async def run_command_tests(bot: commands.Bot) -> dict[str, str]:
+    results: dict[str, str] = {}
+
+    class DummyResponse:
+        async def send_message(self, *args, **kwargs):
+            pass
+
+        async def defer(self, *args, **kwargs):
+            pass
+
+    class DummyFollowup:
+        async def send(self, *args, **kwargs):
+            pass
+
+    class DummyUser:
+        id = 0
+        name = "tester"
+        roles: list[discord.Role] = []
+        guild_permissions = discord.Permissions.none()
+        premium_since = None
+
+    class DummyInteraction:
+        user = DummyUser()
+        guild = None
+        channel = None
+        response = DummyResponse()
+        followup = DummyFollowup()
+
+    dummy = DummyInteraction()
+
+    for cmd in bot.tree.get_commands():
+        try:
+            sig = inspect.signature(cmd.callback)
+            params = list(sig.parameters.values())[1:]
+            args = []
+            for p in params:
+                if p.default is inspect.Parameter.empty:
+                    raise TypeError("Missing parameters")
+                args.append(p.default)
+            await cmd.callback(dummy, *args)
+            results[cmd.name] = "OK"
+        except Exception as e:
+            results[cmd.name] = f"Error: {e}"
+    return results
+
+
 active_prison_timers: dict[int, asyncio.Task] = {}
 
 
 def setup(bot: commands.Bot):
+    @bot.tree.command(name="test", description="Test all commands")
+    async def test_commands(inter: discord.Interaction):
+        if not has_role(inter.user, ADMIN_ROLE_ID):
+            await inter.response.send_message("No permission.", ephemeral=True)
+            return
+        await inter.response.defer(thinking=True, ephemeral=True)
+        results = await run_command_tests(bot)
+        report_lines = [f"{name}: {status}" for name, status in results.items()]
+        report = "\n".join(report_lines)
+        if len(report) > 1900:
+            file = discord.File(io.StringIO(report), filename="command_report.txt")
+            await inter.followup.send("**Testergebnis**:", file=file, ephemeral=True)
+        else:
+            await inter.followup.send(f"**Testergebnis**:\n{report}", ephemeral=True)
+
     @bot.tree.command(
         name="setstatpoints", description="Set a user's stat points (Admin only)"
     )


### PR DESCRIPTION
## Summary
- add `run_command_tests` helper to run command callbacks with a dummy interaction
- add `/test` slash command for admins to execute the tests
- prevent test command output from exceeding Discord's message length by sending long reports as a file

## Testing
- `python -m py_compile commands/admin_commands.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68904fc481b08327a6dc3b323ea25e79