### PR TITLE
feat: store trigger responses in database

### DIFF
--- a/commands/admin_commands.py
+++ b/commands/admin_commands.py
@@ -735,6 +735,44 @@ def setup(bot: commands.Bot):
             return
         await interaction.response.send_message(", ".join(sorted(words)))
 
+    @bot.tree.command(name="addtrigger", description="Add a trigger response")
+    @app_commands.describe(trigger="Trigger word", response="Response message")
+    @app_commands.checks.has_permissions(manage_messages=True)
+    async def addtrigger(
+        interaction: discord.Interaction, trigger: str, response: str
+    ):
+        from db.DBHelper import add_trigger_response
+        from events import trigger_responses
+
+        add_trigger_response(trigger, response)
+        trigger_responses[trigger.lower()] = response
+        await interaction.response.send_message(
+            f"\u2705 Added trigger `{trigger}`.", ephemeral=True
+        )
+
+    @bot.tree.command(name="removetrigger", description="Remove a trigger response")
+    @app_commands.describe(trigger="Trigger word")
+    @app_commands.checks.has_permissions(manage_messages=True)
+    async def removetrigger(interaction: discord.Interaction, trigger: str):
+        from db.DBHelper import remove_trigger_response
+        from events import trigger_responses
+
+        remove_trigger_response(trigger)
+        trigger_responses.pop(trigger.lower(), None)
+        await interaction.response.send_message(
+            f"\u2705 Removed trigger `{trigger}`.", ephemeral=True
+        )
+
+    @bot.tree.command(name="triggers", description="Show all trigger responses")
+    async def triggers(interaction: discord.Interaction):
+        from db.DBHelper import get_trigger_responses
+
+        data = get_trigger_responses()
+        if not data:
+            await interaction.response.send_message("No trigger responses.")
+            return
+        await interaction.response.send_message(", ".join(sorted(data.keys())))
+
     @bot.tree.command(
         name="createrole",
         description="Create a role and assign to users (for goodyb & nannapat2410 only)",
@@ -810,6 +848,9 @@ def setup(bot: commands.Bot):
         addfilterword,
         removefilterword,
         filterwords,
+        addtrigger,
+        removetrigger,
+        triggers,
         createrole,
         manageViltrumite,
         manageYeager,

--- a/config.py
+++ b/config.py
@@ -16,46 +16,6 @@ SUPERPOWER_COST = 80_000
 SUPERPOWER_COOLDOWN_HOURS = 24
 STAT_NAMES = ["intelligence", "strength", "stealth"]
 
-TRIGGER_RESPONSES = {
-    "シャドウストーム": (
-        "Our beautiful majestic Emperor シャドウストーム! "
-        "Long live our beloved King 👑"
-    ),
-    "goodyb": (
-        "Our beautiful majestic Emperor goodyb! " "Long live our beloved King 👑"
-    ),
-    "Taoma": (
-        "Our beautiful majestic Emperor TAOMA™! " "Long live our beloved King 👑"
-    ),
-    "T*oma": (
-        "Our beautiful majestic Emperor TAOMA™! " "Long live our beloved King 👑"
-    ),
-    "Ta0ma": (
-        "Our beautiful majestic Emperor TAOMA™! " "Long live our beloved King 👑"
-    ),
-    "Ta*ma": (
-        "Our beautiful majestic Emperor TAOMA™! " "Long live our beloved King 👑"
-    ),
-    "Taom*": (
-        "Our beautiful majestic Emperor TAOMA™! " "Long live our beloved King 👑"
-    ),
-    "T a o m a": (
-        "Our beautiful majestic Emperor TAOMA™! " "Long live our beloved King 👑"
-    ),
-    "Taomi": (
-        "Our beautiful majestic Emperor TAOMA™! " "Long live our beloved King 👑"
-    ),
-    "Toami": (
-        "Our beautiful majestic Emperor TAOMA™! " "Long live our beloved King 👑"
-    ),
-    "taôma": (
-        "Our beautiful majestic Emperor TAOMA™! " "Long live our beloved King 👑"
-    ),
-    "Ta@ma": (
-        "Our beautiful majestic Emperor TAOMA™! " "Long live our beloved King 👑"
-    ),
-}
-
 ROLE_THRESHOLDS = {
     "intelligence": ("Neuromancer", 50),
     "strength": ("Warriour", 100),

--- a/db/DBHelper.py
+++ b/db/DBHelper.py
@@ -335,6 +335,27 @@ def get_filtered_words() -> list[str]:
     return [row[0] for row in rows]
 
 
+# ---------- trigger response helpers ----------
+
+def add_trigger_response(trigger: str, response: str):
+    _execute(
+        "INSERT OR REPLACE INTO trigger_responses (trigger, response) VALUES (?, ?)",
+        (trigger.lower(), response),
+    )
+
+
+def remove_trigger_response(trigger: str):
+    _execute("DELETE FROM trigger_responses WHERE trigger = ?", (trigger.lower(),))
+
+
+def get_trigger_responses() -> dict:
+    conn = sqlite3.connect(DB_PATH)
+    cursor = conn.cursor()
+    cursor.execute("SELECT trigger, response FROM trigger_responses")
+    rows = cursor.fetchall()
+    conn.close()
+    return {trigger: response for trigger, response in rows}
+
 # ---------- anti nuke helpers ----------
 
 def get_anti_nuke_setting(category: str) -> Optional[Tuple[int, int, str, Optional[int]]]:

--- a/db/initializeDB.py
+++ b/db/initializeDB.py
@@ -134,6 +134,15 @@ def init_db():
 
     cursor.execute(
         """
+        CREATE TABLE IF NOT EXISTS trigger_responses (
+            trigger TEXT PRIMARY KEY,
+            response TEXT NOT NULL
+        )
+        """
+    )
+
+    cursor.execute(
+        """
         CREATE TABLE IF NOT EXISTS anti_nuke_settings (
             category TEXT PRIMARY KEY,
             enabled INTEGER DEFAULT 0,


### PR DESCRIPTION
## Summary
- store trigger messages in a new `trigger_responses` table
- fetch trigger replies from the database and respond dynamically
- add admin commands to add/remove/list trigger responses

## Testing
- `python -m py_compile commands/admin_commands.py config.py db/DBHelper.py db/initializeDB.py events.py`


------
https://chatgpt.com/codex/tasks/task_e_68907a08efe08327a536bdff1519d174