### PR TITLE
Improve command test harness and slap fallback

### DIFF
--- a/commands/fun_commands.py
+++ b/commands/fun_commands.py
@@ -240,18 +240,26 @@ def setup(bot: commands.Bot):
 
     @bot.tree.command(name="slap", description="slap another user")
     async def slap(interaction: discord.Interaction, user: discord.Member):
-        response = requests.get(
-            "https://api.otakugifs.xyz/gif?reaction=slap&format=gif"
-        )
-
-        gif = response.json()
-        gif = gif["url"]
+        try:
+            response = requests.get(
+                "https://api.otakugifs.xyz/gif?reaction=slap&format=gif",
+                timeout=5,
+            )
+            response.raise_for_status()
+            data = response.json()
+            gif = data.get("url", "")
+        except requests.RequestException:
+            gif = ""
         embed = discord.Embed(
             title=f"{interaction.user.display_name} slaps {user.display_name} really hard!",
             color=discord.Color.red(),
         )
-        embed.set_image(url=gif)
-        await interaction.response.send_message(embed=embed)
+        if gif:
+            embed.set_image(url=gif)
+        await interaction.response.send_message(
+            embed=embed if gif else None,
+            content=None if gif else "*whiff* Can't fetch a slap gif right now.",
+        )
 
     @bot.tree.command(name="lick", description="Lick another member")
     async def lick(interaction: discord.Interaction, user: discord.Member):


### PR DESCRIPTION
## Summary
- make test harness more resilient: add avatar/webhook stubs, filter `None` roles, and skip self-test command
- guard `slap` command against HTTP failures with timeout and fallback message

## Testing
- `python -m py_compile commands/admin_commands.py commands/fun_commands.py utils.py`
- `python - <<'PY'
import asyncio
from discord.ext import commands
import commands.action_commands as action
import commands.admin_commands as admin
import commands.antinuke_commands as antinuke
import commands.booster_commands as booster
import commands.economy_commands as economy
import commands.fun_commands as fun
import commands.stats_commands as stats

bot = commands.Bot(command_prefix='!')
for m in [action, admin, antinuke, booster, economy, fun, stats]:
    m.setup(bot)

async def main():
    results = await admin.run_command_tests(bot)
    for name, status in results.items():
        print(f"{name}: {status}")

asyncio.run(main())
PY` *(fails: ModuleNotFoundError: No module named 'discord')*
- `pip install discord.py` *(fails: Could not find a version that satisfies the requirement discord.py; Tunnel connection failed: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68908b8e9200832789baea2db6b00583