### PR TITLE
feat: store guild-specific settings

### DIFF
--- a/commands/admin_commands.py
+++ b/commands/admin_commands.py
@@ -740,7 +740,7 @@ def setup(bot: commands.Bot):
     async def addfilterword(interaction: discord.Interaction, word: str):
         from db.DBHelper import add_filtered_word
 
-        add_filtered_word(word)
+        add_filtered_word(interaction.guild.id, word)
         await interaction.response.send_message(
             f"\u2705 Added `{word}` to the filter.", ephemeral=True
         )
@@ -753,7 +753,7 @@ def setup(bot: commands.Bot):
     async def removefilterword(interaction: discord.Interaction, word: str):
         from db.DBHelper import remove_filtered_word
 
-        remove_filtered_word(word)
+        remove_filtered_word(interaction.guild.id, word)
         await interaction.response.send_message(
             f"\u2705 Removed `{word}` from the filter.", ephemeral=True
         )
@@ -762,7 +762,7 @@ def setup(bot: commands.Bot):
     async def filterwords(interaction: discord.Interaction):
         from db.DBHelper import get_filtered_words
 
-        words = get_filtered_words()
+        words = get_filtered_words(interaction.guild.id)
         if not words:
             await interaction.response.send_message("No filtered words.")
             return
@@ -775,8 +775,8 @@ def setup(bot: commands.Bot):
         from db.DBHelper import add_trigger_response
         from events import trigger_responses
 
-        add_trigger_response(trigger, response)
-        trigger_responses[trigger.lower()] = response
+        add_trigger_response(trigger, response, interaction.guild.id)
+        trigger_responses.setdefault(interaction.guild.id, {})[trigger.lower()] = response
         await interaction.response.send_message(
             f"\u2705 Added trigger `{trigger}`.", ephemeral=True
         )
@@ -788,8 +788,8 @@ def setup(bot: commands.Bot):
         from db.DBHelper import remove_trigger_response
         from events import trigger_responses
 
-        remove_trigger_response(trigger)
-        trigger_responses.pop(trigger.lower(), None)
+        remove_trigger_response(trigger, interaction.guild.id)
+        trigger_responses.get(interaction.guild.id, {}).pop(trigger.lower(), None)
         await interaction.response.send_message(
             f"\u2705 Removed trigger `{trigger}`.", ephemeral=True
         )
@@ -798,7 +798,7 @@ def setup(bot: commands.Bot):
     async def triggers(interaction: discord.Interaction):
         from db.DBHelper import get_trigger_responses
 
-        data = get_trigger_responses()
+        data = get_trigger_responses(interaction.guild.id)
         if not data:
             await interaction.response.send_message("No trigger responses.")
             return

--- a/commands/antinuke_commands.py
+++ b/commands/antinuke_commands.py
@@ -54,7 +54,9 @@ def setup(bot: commands.Bot):
             await interaction.response.send_message("Invalid category.", ephemeral=True)
             return
         dur_s = parse_duration(duration) if duration else None
-        set_anti_nuke_setting(category, int(enabled), threshold, punishment, dur_s)
+        set_anti_nuke_setting(
+            category, int(enabled), threshold, punishment, dur_s, interaction.guild.id
+        )
         await interaction.response.send_message("Saved.", ephemeral=True)
 
     @bot.tree.command(name="antinukeignoreuser", description="Toggle safe user")
@@ -62,11 +64,12 @@ def setup(bot: commands.Bot):
         if interaction.user.id != OWNER_ID:
             await interaction.response.send_message("No permission.", ephemeral=True)
             return
-        if user.id in get_safe_users():
-            remove_safe_user(user.id)
+        guild_id = interaction.guild.id
+        if user.id in get_safe_users(guild_id):
+            remove_safe_user(guild_id, user.id)
             await interaction.response.send_message("User removed from safe list.", ephemeral=True)
         else:
-            add_safe_user(user.id)
+            add_safe_user(guild_id, user.id)
             await interaction.response.send_message("User added to safe list.", ephemeral=True)
 
     @bot.tree.command(name="antinukeignorerole", description="Toggle safe role")
@@ -74,11 +77,12 @@ def setup(bot: commands.Bot):
         if interaction.user.id != OWNER_ID:
             await interaction.response.send_message("No permission.", ephemeral=True)
             return
-        if role.id in get_safe_roles():
-            remove_safe_role(role.id)
+        guild_id = interaction.guild.id
+        if role.id in get_safe_roles(guild_id):
+            remove_safe_role(guild_id, role.id)
             await interaction.response.send_message("Role removed from safe list.", ephemeral=True)
         else:
-            add_safe_role(role.id)
+            add_safe_role(guild_id, role.id)
             await interaction.response.send_message("Role added to safe list.", ephemeral=True)
 
     @bot.tree.command(name="antinukelog", description="Set anti nuke log channel")
@@ -86,7 +90,7 @@ def setup(bot: commands.Bot):
         if interaction.user.id != OWNER_ID:
             await interaction.response.send_message("No permission.", ephemeral=True)
             return
-        set_anti_nuke_log_channel(channel.id)
+        set_anti_nuke_log_channel(interaction.guild.id, channel.id)
         await interaction.response.send_message(
             f"Log channel set to {channel.mention}", ephemeral=True
         )
@@ -97,8 +101,9 @@ def setup(bot: commands.Bot):
             await interaction.response.send_message("No permission.", ephemeral=True)
             return
         lines = []
+        gid = interaction.guild.id
         for cat in CATEGORIES:
-            setting = get_anti_nuke_setting(cat)
+            setting = get_anti_nuke_setting(cat, gid)
             if setting:
                 en, th, p, dur = setting
                 desc = f"on" if en else "off"
@@ -109,9 +114,9 @@ def setup(bot: commands.Bot):
                 desc = "not set"
             lines.append(f"**{cat}**: {desc}")
 
-        users = [f"<@{u}>" for u in get_safe_users()] or ["None"]
-        roles = [f"<@&{r}>" for r in get_safe_roles()] or ["None"]
-        cid = get_anti_nuke_log_channel()
+        users = [f"<@{u}>" for u in get_safe_users(gid)] or ["None"]
+        roles = [f"<@&{r}>" for r in get_safe_roles(gid)] or ["None"]
+        cid = get_anti_nuke_log_channel(gid)
         log_line = f"<#{cid}>" if cid else "None"
         lines.append(f"Safe users: {', '.join(users)}")
         lines.append(f"Safe roles: {', '.join(roles)}")


### PR DESCRIPTION
## Summary
- persist filtered words, trigger responses, and anti-nuke config per guild
- update commands and events to read/write guild-specific settings

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68908fed597483279ef905e930c2dbfa