### PR TITLE
Propagate role updates and allow removing command roles

### DIFF
--- a/commands/admin_commands.py
+++ b/commands/admin_commands.py
@@ -34,6 +34,7 @@ from db.DBHelper import (
     set_role,
     get_role,
     set_command_permission,
+    remove_command_permission,
 )
 from utils import has_role, has_command_permission, get_channel_webhook, parse_duration
 
@@ -905,6 +906,17 @@ def setup(bot: commands.Bot):
         )
 
     @bot.tree.command(
+        name="removecommandrole", description="Remove required role for a command"
+    )
+    @app_commands.describe(command="Command name")
+    @app_commands.checks.has_permissions(manage_guild=True)
+    async def removecommandrole(interaction: discord.Interaction, command: str):
+        remove_command_permission(command)
+        await interaction.response.send_message(
+            f"\u2705 Removed {command} command role.", ephemeral=True
+        )
+
+    @bot.tree.command(
         name="createrole",
         description="Create a role and assign to users (for goodyb & nannapat2410 only)",
     )
@@ -989,6 +1001,8 @@ def setup(bot: commands.Bot):
         setboostchannel,
         setboostmsg,
         setrole,
+        setcommandrole,
+        removecommandrole,
         createrole,
         manageViltrumite,
         manageYeager,

--- a/db/DBHelper.py
+++ b/db/DBHelper.py
@@ -269,10 +269,16 @@ def get_booster_message() -> Optional[str]:
 
 
 def set_role(name: str, role_id: int) -> None:
+    old_id = get_role(name)
     _execute(
         "INSERT OR REPLACE INTO roles (name, role_id) VALUES (?, ?)",
         (name, str(role_id)),
     )
+    if old_id is not None and old_id != role_id:
+        _execute(
+            "UPDATE command_permissions SET role_id = ? WHERE role_id = ?",
+            (str(role_id), str(old_id)),
+        )
 
 
 def get_role(name: str) -> Optional[int]:
@@ -293,6 +299,10 @@ def get_command_permission(command: str) -> Optional[int]:
         (command,),
     )
     return int(row[0]) if row and row[0] else None
+
+
+def remove_command_permission(command: str) -> None:
+    _execute("DELETE FROM command_permissions WHERE command = ?", (command,))
 
 
 # ---------- shop helpers ----------

--- a/db/initializeDB.py
+++ b/db/initializeDB.py
@@ -12,10 +12,6 @@ def init_db():
         if not existing or not required_cols.issubset(existing):
             cursor.execute(f"DROP TABLE IF EXISTS {table}")
             cursor.execute(create_sql)
-    cursor.execute("PRAGMA table_info(dates)")
-    columns = {col[1] for col in cursor.fetchall()}
-    if "registered_date" not in columns:
-        cursor.execute("ALTER TABLE dates ADD COLUMN registered_date TEXT")
 
     cursor.execute(
         """
@@ -151,6 +147,11 @@ def init_db():
         )
         """
     )
+
+    cursor.execute("PRAGMA table_info(dates)")
+    columns = {col[1] for col in cursor.fetchall()}
+    if "registered_date" not in columns:
+        cursor.execute("ALTER TABLE dates ADD COLUMN registered_date TEXT")
 
     cursor.execute(
         """


### PR DESCRIPTION
## Summary
- Update command permissions when a named role changes so existing command restrictions follow the new role
- Add `/removecommandrole` to clear explicit role restrictions from commands

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_689094171abc83279456a060a1e004a0