### PR TITLE
Propagate role updates and add role removal commands

### DIFF
--- a/db/DBHelper.py
+++ b/db/DBHelper.py
@@ -269,15 +269,32 @@ def get_booster_message() -> Optional[str]:
 
 
 def set_role(name: str, role_id: int) -> None:
+    old_id = get_role(name)
     _execute(
         "INSERT OR REPLACE INTO roles (name, role_id) VALUES (?, ?)",
         (name, str(role_id)),
     )
+    if old_id is not None and old_id != role_id:
+        _execute(
+            "UPDATE command_permissions SET role_id = ? WHERE role_id = ?",
+            (str(role_id), str(old_id)),
+        )
 
 
 def get_role(name: str) -> Optional[int]:
     row = _fetchone("SELECT role_id FROM roles WHERE name = ?", (name,))
     return int(row[0]) if row and row[0] else None
+
+
+def remove_role(name: str) -> None:
+    role_id = get_role(name)
+    if role_id is None:
+        return
+    _execute("DELETE FROM roles WHERE name = ?", (name,))
+    _execute(
+        "UPDATE command_permissions SET role_id = NULL WHERE role_id = ?",
+        (str(role_id),),
+    )
 
 
 def set_command_permission(command: str, role_id: int) -> None:
@@ -293,6 +310,10 @@ def get_command_permission(command: str) -> Optional[int]:
         (command,),
     )
     return int(row[0]) if row and row[0] else None
+
+
+def remove_command_permission(command: str) -> None:
+    _execute("DELETE FROM command_permissions WHERE command = ?", (command,))
 
 
 # ---------- shop helpers ----------

--- a/db/initializeDB.py
+++ b/db/initializeDB.py
@@ -12,10 +12,6 @@ def init_db():
         if not existing or not required_cols.issubset(existing):
             cursor.execute(f"DROP TABLE IF EXISTS {table}")
             cursor.execute(create_sql)
-    cursor.execute("PRAGMA table_info(dates)")
-    columns = {col[1] for col in cursor.fetchall()}
-    if "registered_date" not in columns:
-        cursor.execute("ALTER TABLE dates ADD COLUMN registered_date TEXT")
 
     cursor.execute(
         """
@@ -151,6 +147,11 @@ def init_db():
         )
         """
     )
+
+    cursor.execute("PRAGMA table_info(dates)")
+    columns = {col[1] for col in cursor.fetchall()}
+    if "registered_date" not in columns:
+        cursor.execute("ALTER TABLE dates ADD COLUMN registered_date TEXT")
 
     cursor.execute(
         """


### PR DESCRIPTION
## Summary
- Update command permissions when a named role changes so existing command restrictions follow the new role
- Add `/removecommandrole` to clear explicit role restrictions from commands
- Protect real data by running command tests against a temporary database
- Add `/removerole` to delete stored role mappings

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_689094171abc83279456a060a1e004a0