### PR TITLE
Scope lowercase lock to guilds

### DIFF
--- a/commands/fun_commands.py
+++ b/commands/fun_commands.py
@@ -3,11 +3,12 @@ from discord import app_commands
 from discord.ext import commands
 from random import choice, random
 from typing import Optional
+from collections import defaultdict
 from db.DBHelper import get_role
 from utils import has_role
 import requests
 
-lowercase_locked: set[int] = set()
+lowercase_locked: dict[int, set[int]] = defaultdict(set)
 
 
 def setup(bot: commands.Bot):
@@ -18,14 +19,15 @@ def setup(bot: commands.Bot):
     @app_commands.describe(member="Member to lock/unlock")
     @app_commands.checks.has_permissions(manage_messages=True)
     async def forcelowercase(interaction: discord.Interaction, member: discord.Member):
-        if member.id in lowercase_locked:
-            lowercase_locked.remove(member.id)
+        locked = lowercase_locked[interaction.guild.id]
+        if member.id in locked:
+            locked.remove(member.id)
             await interaction.response.send_message(
                 f"🔓 {member.display_name} unlocked – messages stay unchanged.",
                 ephemeral=True,
             )
         else:
-            lowercase_locked.add(member.id)
+            locked.add(member.id)
             await interaction.response.send_message(
                 f"🔒 {member.display_name} locked – messages will be lower-cased.",
                 ephemeral=True,

--- a/events.py
+++ b/events.py
@@ -141,11 +141,12 @@ async def on_member_update(
 
 
 async def on_message(
-    bot: commands.Bot, message: discord.Message, lowercase_locked: set[int]
+    bot: commands.Bot, message: discord.Message, lowercase_locked: dict[int, set[int]]
 ):
     if message.author.bot or message.webhook_id or not message.guild:
         return
-    if message.author.id in lowercase_locked:
+    locked = lowercase_locked.get(message.guild.id, set())
+    if message.author.id in locked:
         try:
             await message.delete()
         except discord.Forbidden:
@@ -365,7 +366,7 @@ async def on_app_command_completion(
     await log_ch.send(embed=embed)
 
 
-def setup(bot: commands.Bot, lowercase_locked: set[int]):
+def setup(bot: commands.Bot, lowercase_locked: dict[int, set[int]]):
     async def ready_wrapper():
         await on_ready(bot)
 


### PR DESCRIPTION
## Summary
- track lowercase-locked members per guild
- respect guild-specific lock list in events handler

## Testing
- `python -m py_compile commands/fun_commands.py events.py`


------
https://chatgpt.com/codex/tasks/task_e_6890ad602c788327b085a307b40f1032