### PR TITLE
Add guild scoped custom booster roles

### DIFF
--- a/commands/booster_commands.py
+++ b/commands/booster_commands.py
@@ -25,7 +25,7 @@ def setup(bot: commands.Bot):
             )
             return
 
-        role_id = get_custom_role(str(member.id))
+        role_id = get_custom_role(guild.id, str(member.id))
 
         if role_id:
             role = guild.get_role(role_id)
@@ -41,7 +41,7 @@ def setup(bot: commands.Bot):
                 name=name, colour=colour_obj, reason="Custom booster role"
             )
             await member.add_roles(role, reason="Assigned custom booster role")
-            set_custom_role(str(member.id), role.id)
+            set_custom_role(guild.id, str(member.id), role.id)
             await interaction.response.send_message(
                 f"✅ Custom role **{name}** created and assigned!", ephemeral=True
             )
@@ -65,7 +65,7 @@ def setup(bot: commands.Bot):
             )
             return
 
-        role_id = get_custom_role(booster_id)
+        role_id = get_custom_role(interaction.guild.id, booster_id)
         if not role_id:
             await interaction.response.send_message(
                 "You don't have a custom role.", ephemeral=True

--- a/db/DBHelper.py
+++ b/db/DBHelper.py
@@ -353,20 +353,26 @@ def get_shop_roles():
     return rows
 
 
-def get_custom_role(user_id: str):
-    row = _fetchone("SELECT role_id FROM custom_roles WHERE user_id = ?", (user_id,))
+def get_custom_role(guild_id: int, user_id: str):
+    row = _fetchone(
+        "SELECT role_id FROM custom_roles WHERE guild_id = ? AND user_id = ?",
+        (str(guild_id), user_id),
+    )
     return int(row[0]) if row else None
 
 
-def set_custom_role(user_id: str, role_id: int):
+def set_custom_role(guild_id: int, user_id: str, role_id: int):
     _execute(
-        "INSERT OR REPLACE INTO custom_roles (user_id, role_id) VALUES (?, ?)",
-        (user_id, role_id),
+        "INSERT OR REPLACE INTO custom_roles (guild_id, user_id, role_id) VALUES (?, ?, ?)",
+        (str(guild_id), user_id, role_id),
     )
 
 
-def delete_custom_role(user_id: str):
-    _execute("DELETE FROM custom_roles WHERE user_id = ?", (user_id,))
+def delete_custom_role(guild_id: int, user_id: str):
+    _execute(
+        "DELETE FROM custom_roles WHERE guild_id = ? AND user_id = ?",
+        (str(guild_id), user_id),
+    )
 
 
 # ---------- anime title helpers ----------

--- a/db/initializeDB.py
+++ b/db/initializeDB.py
@@ -115,13 +115,17 @@ def init_db():
     """
     )
 
-    cursor.execute(
+    _recreate(
+        "custom_roles",
         """
-    CREATE TABLE IF NOT EXISTS custom_roles (
-        user_id TEXT PRIMARY KEY,
-        role_id TEXT NOT NULL
-    )
-    """
+        CREATE TABLE IF NOT EXISTS custom_roles (
+            guild_id TEXT,
+            user_id TEXT,
+            role_id TEXT NOT NULL,
+            PRIMARY KEY (guild_id, user_id)
+        )
+        """,
+        {"guild_id", "user_id", "role_id"},
     )
 
     cursor.execute(

--- a/events.py
+++ b/events.py
@@ -108,7 +108,7 @@ async def on_member_update(
     bot: commands.Bot, before: discord.Member, after: discord.Member
 ):
     if before.premium_since and not after.premium_since:
-        role_id = get_custom_role(str(after.id))
+        role_id = get_custom_role(after.guild.id, str(after.id))
         if role_id:
             role = after.guild.get_role(role_id)
             if role:
@@ -116,7 +116,7 @@ async def on_member_update(
                     await role.delete(reason="User stopped boosting")
                 except Exception:
                     pass
-            delete_custom_role(str(after.id))
+            delete_custom_role(after.guild.id, str(after.id))
     if not before.premium_since and after.premium_since:
         cid = get_booster_channel(after.guild.id)
         if cid:


### PR DESCRIPTION
## Summary
- include guild_id in custom_roles table and operations
- ensure booster role management targets specific guilds

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6890b0c4e3b883278ea38be9bdf75ac3