### PR TITLE
Add command to show server settings

### DIFF
--- a/db/DBHelper.py
+++ b/db/DBHelper.py
@@ -309,6 +309,18 @@ def remove_role(guild_id: int, name: str) -> None:
     )
 
 
+def get_roles(guild_id: int) -> dict[str, int]:
+    conn = sqlite3.connect(DB_PATH)
+    cursor = conn.cursor()
+    cursor.execute(
+        "SELECT name, role_id FROM roles WHERE guild_id = ?",
+        (str(guild_id),),
+    )
+    rows = cursor.fetchall()
+    conn.close()
+    return {name: int(rid) for name, rid in rows}
+
+
 def set_command_permission(guild_id: int, command: str, role_id: int) -> None:
     _execute(
         "INSERT OR REPLACE INTO command_permissions (guild_id, command, role_id) VALUES (?, ?, ?)",
@@ -329,6 +341,18 @@ def remove_command_permission(guild_id: int, command: str) -> None:
         "DELETE FROM command_permissions WHERE guild_id = ? AND command = ?",
         (str(guild_id), command),
     )
+
+
+def get_command_permissions(guild_id: int) -> dict[str, int]:
+    conn = sqlite3.connect(DB_PATH)
+    cursor = conn.cursor()
+    cursor.execute(
+        "SELECT command, role_id FROM command_permissions WHERE guild_id = ?",
+        (str(guild_id),),
+    )
+    rows = cursor.fetchall()
+    conn.close()
+    return {cmd: int(rid) for cmd, rid in rows}
 
 
 # ---------- shop helpers ----------


### PR DESCRIPTION
## Summary
- show current per-server configuration via `/serversettings`
- support fetching roles and command permissions from DB

## Testing
- `python -m py_compile db/DBHelper.py commands/admin_commands.py`
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_6890b410c7388327823dd1deaac36272