### PR TITLE
Fix command permission lookup

### DIFF
--- a/db/DBHelper.py
+++ b/db/DBHelper.py
@@ -339,12 +339,12 @@ def set_command_permission(guild_id: int, command: str, role_id: int) -> None:
     )
 
 
-def get_command_permission(guild_id: int) -> dict[str, int]:
-    rows = _fetchall(
-        "SELECT command, role_id FROM command_permissions WHERE guild_id = ?",
-        (guild_id,),
+def get_command_permission(guild_id: int, command: str) -> Optional[int]:
+    row = _fetchone(
+        "SELECT role_id FROM command_permissions WHERE guild_id = ? AND command = ?",
+        (str(guild_id), command),
     )
-    return {cmd: int(rid) for cmd, rid in rows if rid is not None}
+    return int(row[0]) if row and row[0] is not None else None
 
 
 def remove_command_permission(guild_id: int, command: str) -> None:


### PR DESCRIPTION
## Summary
- accept command argument in `get_command_permission`

## Testing
- `python -m py_compile db/DBHelper.py utils.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6891ef1244548327946ad7645ffab352