### PR TITLE
Add prison setup command

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -10,6 +10,7 @@ from commands.action_commands import setup as setup_action
 from commands.admin_commands import setup as setup_admin
 from commands.antinuke_commands import setup as setup_antinuke
 from commands.setup_wizard import setup as setup_wizard
+from commands.prison_commands import setup as setup_prison
 import events
 import anti_nuke
 
@@ -29,6 +30,7 @@ setup_action(bot)
 setup_admin(bot)
 setup_antinuke(bot)
 setup_wizard(bot)
+setup_prison(bot)
 events.setup(bot, lowercase_locked)
 anti_nuke.setup(bot)
 

--- a/commands/prison_commands.py
+++ b/commands/prison_commands.py
@@ -1,0 +1,219 @@
+import discord
+from discord import app_commands
+from discord.ext import commands
+from typing import List
+
+from db.DBHelper import set_prison_settings
+
+
+class PrisonSetupView(discord.ui.View):
+    def __init__(self, interaction: discord.Interaction):
+        super().__init__(timeout=600)
+        self.interaction = interaction
+        self.guild = interaction.guild
+        self.message: discord.Message | None = None
+        self.prison_channel: discord.TextChannel | None = None
+        self.prison_role: discord.Role | None = None
+        self.immunized_roles: List[discord.Role] = []
+        self.allowed_channels: List[discord.TextChannel] = []
+        self.prison_exceptions: List[discord.TextChannel] = []
+
+    async def start(self):
+        await self.ask_prison_channel(self.interaction)
+
+    async def ask_prison_channel(self, interaction: discord.Interaction):
+        self.clear_items()
+        channel_select = discord.ui.ChannelSelect(
+            channel_types=[discord.ChannelType.text],
+            min_values=1,
+            max_values=1,
+            placeholder="Select prison channel",
+        )
+
+        async def on_select(inter: discord.Interaction):
+            self.prison_channel = channel_select.values[0]
+            await self.ask_prison_role(inter)
+
+        channel_select.callback = on_select
+        self.add_item(channel_select)
+
+        if self.message is None:
+            await interaction.response.send_message(
+                "Choose the channel to be used as the prison.",
+                view=self,
+                ephemeral=True,
+            )
+            self.message = await interaction.original_response()
+        else:
+            await interaction.response.edit_message(
+                content="Choose the channel to be used as the prison.", view=self
+            )
+
+    async def ask_prison_role(self, interaction: discord.Interaction):
+        self.clear_items()
+        role_select = discord.ui.RoleSelect(
+            placeholder="Select prison role (optional)",
+            min_values=0,
+            max_values=1,
+        )
+        auto_button = discord.ui.Button(
+            label="Automatic", style=discord.ButtonStyle.primary
+        )
+
+        async def role_selected(inter: discord.Interaction):
+            if role_select.values:
+                self.prison_role = role_select.values[0]
+                await self.ask_immunized_roles(inter)
+
+        async def auto_selected(inter: discord.Interaction):
+            self.prison_role = await self.guild.create_role(name="Prison role")
+            await self.ask_immunized_roles(inter)
+
+        role_select.callback = role_selected
+        auto_button.callback = auto_selected
+
+        self.add_item(role_select)
+        self.add_item(auto_button)
+        await interaction.response.edit_message(
+            content="Select the role for prisoners or create one automatically.",
+            view=self,
+        )
+
+    async def ask_immunized_roles(self, interaction: discord.Interaction):
+        self.clear_items()
+        role_select = discord.ui.RoleSelect(
+            placeholder="Select roles immune to prison",
+            min_values=0,
+            max_values=25,
+        )
+        next_button = discord.ui.Button(
+            label="Next", style=discord.ButtonStyle.primary
+        )
+
+        async def next_step(inter: discord.Interaction):
+            self.immunized_roles = role_select.values
+            await self.ask_normal_channels(inter)
+
+        next_button.callback = next_step
+        self.add_item(role_select)
+        self.add_item(next_button)
+        await interaction.response.edit_message(
+            content="Select roles that cannot be imprisoned (optional).",
+            view=self,
+        )
+
+    async def ask_normal_channels(self, interaction: discord.Interaction):
+        self.clear_items()
+        channel_select = discord.ui.ChannelSelect(
+            channel_types=[discord.ChannelType.text],
+            min_values=0,
+            max_values=25,
+            placeholder="Channels where normal users can chat",
+        )
+        next_button = discord.ui.Button(
+            label="Next", style=discord.ButtonStyle.primary
+        )
+
+        async def next_step(inter: discord.Interaction):
+            self.allowed_channels = channel_select.values
+            await self.ask_prison_exceptions(inter)
+
+        next_button.callback = next_step
+        self.add_item(channel_select)
+        self.add_item(next_button)
+        await interaction.response.edit_message(
+            content="Select normal communication channels.", view=self
+        )
+
+    async def ask_prison_exceptions(self, interaction: discord.Interaction):
+        self.clear_items()
+        channel_select = discord.ui.ChannelSelect(
+            channel_types=[discord.ChannelType.text],
+            min_values=0,
+            max_values=25,
+            placeholder="Extra channels prisoners may access",
+        )
+        skip_button = discord.ui.Button(
+            label="Skip", style=discord.ButtonStyle.secondary
+        )
+        finish_button = discord.ui.Button(
+            label="Finish", style=discord.ButtonStyle.primary
+        )
+
+        async def finish(inter: discord.Interaction):
+            self.prison_exceptions = channel_select.values
+            await self.finalize(inter)
+
+        async def skip(inter: discord.Interaction):
+            await self.finalize(inter)
+
+        finish_button.callback = finish
+        skip_button.callback = skip
+        self.add_item(channel_select)
+        self.add_item(skip_button)
+        self.add_item(finish_button)
+        await interaction.response.edit_message(
+            content="Select additional channels for prisoners (optional).",
+            view=self,
+        )
+
+    async def finalize(self, interaction: discord.Interaction):
+        await interaction.response.defer(ephemeral=True, thinking=True)
+
+        # Save settings
+        set_prison_settings(
+            self.guild.id,
+            self.prison_channel.id if self.prison_channel else 0,
+            self.prison_role.id if self.prison_role else 0,
+            [r.id for r in self.immunized_roles],
+            [c.id for c in self.allowed_channels],
+            [c.id for c in self.prison_exceptions],
+        )
+
+        # Configure normal channels
+        for ch in self.allowed_channels:
+            try:
+                await ch.set_permissions(self.guild.default_role, send_messages=False)
+                if self.prison_role:
+                    await ch.set_permissions(self.prison_role, send_messages=True)
+                for role in self.immunized_roles:
+                    await ch.set_permissions(role, send_messages=True)
+            except Exception:
+                pass
+
+        # Configure prison channel
+        if self.prison_channel and self.prison_role:
+            try:
+                await self.prison_channel.set_permissions(
+                    self.guild.default_role, send_messages=True
+                )
+                await self.prison_channel.set_permissions(
+                    self.prison_role, send_messages=False
+                )
+            except Exception:
+                pass
+
+        for ch in self.prison_exceptions:
+            try:
+                await ch.set_permissions(self.guild.default_role, send_messages=True)
+            except Exception:
+                pass
+
+        # Assign prison role to all members
+        if self.prison_role:
+            for member in self.guild.members:
+                if self.prison_role not in member.roles:
+                    try:
+                        await member.add_roles(self.prison_role)
+                    except Exception:
+                        pass
+
+        await self.message.edit(content="Prison setup complete.", view=None)
+
+
+def setup(bot: commands.Bot):
+    @bot.tree.command(name="setupprison", description="Setup the prison system")
+    @app_commands.checks.has_permissions(manage_guild=True)
+    async def setup_prison(interaction: discord.Interaction):
+        view = PrisonSetupView(interaction)
+        await view.start()

--- a/db/DBHelper.py
+++ b/db/DBHelper.py
@@ -627,3 +627,39 @@ def get_anti_nuke_log_channel(guild_id: int) -> Optional[int]:
         (str(guild_id),),
     )
     return int(row[0]) if row else None
+
+
+# ---------- prison setup ----------
+
+
+def set_prison_settings(
+    guild_id: int,
+    prison_channel: int,
+    prison_role: int,
+    immunized_roles: list[int],
+    allowed_channels: list[int],
+    prisoner_exceptions: list[int],
+) -> None:
+    _execute(
+        """
+        INSERT OR REPLACE INTO prison_settings
+            (guild_id, prison_channel_id, prison_role_id, immunized_roles, allowed_channels, prisoner_exceptions)
+        VALUES (?, ?, ?, ?, ?, ?)
+        """,
+        (
+            str(guild_id),
+            str(prison_channel),
+            str(prison_role),
+            ",".join(map(str, immunized_roles)),
+            ",".join(map(str, allowed_channels)),
+            ",".join(map(str, prisoner_exceptions)),
+        ),
+    )
+
+
+def get_prison_role(guild_id: int) -> Optional[int]:
+    row = _fetchone(
+        "SELECT prison_role_id FROM prison_settings WHERE guild_id = ?",
+        (str(guild_id),),
+    )
+    return int(row[0]) if row and row[0] else None

--- a/db/initializeDB.py
+++ b/db/initializeDB.py
@@ -240,6 +240,28 @@ def init_db():
         {"guild_id", "channel_id"},
     )
 
+    _recreate(
+        "prison_settings",
+        """
+        CREATE TABLE IF NOT EXISTS prison_settings (
+            guild_id TEXT PRIMARY KEY,
+            prison_channel_id TEXT,
+            prison_role_id TEXT,
+            immunized_roles TEXT,
+            allowed_channels TEXT,
+            prisoner_exceptions TEXT
+        )
+        """,
+        {
+            "guild_id",
+            "prison_channel_id",
+            "prison_role_id",
+            "immunized_roles",
+            "allowed_channels",
+            "prisoner_exceptions",
+        },
+    )
+
 
     cursor.execute("PRAGMA table_info(users)")
     existing = {col[1] for col in cursor.fetchall()}

--- a/events.py
+++ b/events.py
@@ -23,6 +23,7 @@ from db.DBHelper import (
     get_booster_channel,
     get_booster_message,
     get_log_channel,
+    get_prison_role,
 )
 from utils import get_channel_webhook
 
@@ -200,6 +201,11 @@ async def on_member_join(bot: commands.Bot, member: discord.Member):
     role = discord.utils.get(member.guild.roles, name="Member")
     if role:
         await member.add_roles(role)
+    pid = get_prison_role(member.guild.id)
+    if pid:
+        prole = member.guild.get_role(pid)
+        if prole:
+            await member.add_roles(prole)
     cid = get_welcome_channel(member.guild.id)
     if cid:
         channel = bot.get_channel(cid)


### PR DESCRIPTION
## Summary
- add `/setupprison` for interactive prison system setup
- persist prison configuration in database and assign roles on member join

## Testing
- `python -m py_compile bot.py db/DBHelper.py db/initializeDB.py events.py commands/prison_commands.py`


------
https://chatgpt.com/codex/tasks/task_e_689211d7535083278520b171ccdc3001