### PR TITLE
Add /explain command for command info

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -11,6 +11,7 @@ from commands.admin_commands import setup as setup_admin
 from commands.antinuke_commands import setup as setup_antinuke
 from commands.setup_wizard import setup as setup_wizard
 from commands.prison_commands import setup as setup_prison
+from commands.explain_commands import setup as setup_explain
 import events
 import anti_nuke
 
@@ -31,6 +32,7 @@ setup_admin(bot)
 setup_antinuke(bot)
 setup_wizard(bot)
 setup_prison(bot)
+setup_explain(bot)
 events.setup(bot, lowercase_locked)
 anti_nuke.setup(bot)
 

--- a/commands/explain_commands.py
+++ b/commands/explain_commands.py
@@ -1,0 +1,51 @@
+import discord
+from discord import app_commands
+from discord.ext import commands
+
+from db.DBHelper import get_command_permission
+
+
+def setup(bot: commands.Bot):
+    @bot.tree.command(name="explain", description="Explain a bot command and its permissions")
+    @app_commands.describe(command="Command to explain")
+    async def explain(interaction: discord.Interaction, command: str):
+        cmd = bot.tree.get_command(command)
+        if cmd is None:
+            await interaction.response.send_message("Unknown command.", ephemeral=True)
+            return
+
+        guild = interaction.guild
+        role_mention = "No specific role required"
+        if guild is not None:
+            role_id = get_command_permission(guild.id, command)
+            if role_id is not None:
+                role = guild.get_role(role_id)
+                if role is not None:
+                    role_mention = role.mention
+                else:
+                    role_mention = f"Role ID {role_id}"
+
+        params_lines: list[str] = []
+        for name, param in cmd.parameters.items():
+            if name in ("self", "interaction"):
+                continue
+            desc = param.description or "No description"
+            params_lines.append(f"`{name}`: {desc}")
+        params_info = "\n".join(params_lines) if params_lines else "None"
+
+        await interaction.response.send_message(
+            f"**/{cmd.name}** - {cmd.description}\n"
+            f"**Parameters:**\n{params_info}\n"
+            f"**Required Role:** {role_mention}",
+            ephemeral=True,
+        )
+
+    @explain.autocomplete("command")
+    async def explain_autocomplete(
+        interaction: discord.Interaction, current: str
+    ) -> list[app_commands.Choice[str]]:
+        commands_list = []
+        for c in bot.tree.get_commands():
+            if current.lower() in c.name.lower():
+                commands_list.append(app_commands.Choice(name=c.name, value=c.name))
+        return commands_list[:25]


### PR DESCRIPTION
## Summary
- add `/explain` command that describes other commands, lists parameters, and shows required role
- register new command with bot startup

## Testing
- `python -m py_compile commands/explain_commands.py bot.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6894ac6a98f88327acc26d3a58ab5401