### PR TITLE
refactor: modularize selected commands

### DIFF
--- a/Commands/boosterPearks/__init__.py
+++ b/Commands/boosterPearks/__init__.py
@@ -1,0 +1,3 @@
+from . import customRole, grantrole
+
+__all__ = ["customRole", "grantrole"]

--- a/Commands/boosterPearks/customRole/__init__.py
+++ b/Commands/boosterPearks/customRole/__init__.py
@@ -1,0 +1,45 @@
+import discord
+from db.DBHelper import get_custom_role, set_custom_role
+
+async def customrole(interaction: discord.Interaction, name: str, color: str):
+    member = interaction.user
+    guild = interaction.guild
+
+    if not member.premium_since:
+        await interaction.response.send_message(
+            "❌ This command is only for server boosters!", ephemeral=True
+        )
+        return
+
+    try:
+        colour_obj = discord.Colour(int(color.lstrip("#"), 16))
+    except ValueError:
+        await interaction.response.send_message(
+            "⚠️ Invalid color. Use hex like #FFAA00", ephemeral=True
+        )
+        return
+
+    role_id = get_custom_role(guild.id, str(member.id))
+
+    if role_id:
+        role = guild.get_role(role_id)
+        if role:
+            await role.edit(name=name, colour=colour_obj)
+            await interaction.response.send_message(
+                f"🔄 Your role has been updated to **{name}**.", ephemeral=True
+            )
+            return
+
+    try:
+        role = await guild.create_role(
+            name=name, colour=colour_obj, reason="Custom booster role"
+        )
+        await member.add_roles(role, reason="Assigned custom booster role")
+        set_custom_role(guild.id, str(member.id), role.id)
+        await interaction.response.send_message(
+            f"✅ Custom role **{name}** created and assigned!", ephemeral=True
+        )
+    except discord.Forbidden:
+        await interaction.response.send_message(
+            "❌ I need permission to manage roles.", ephemeral=True
+        )

--- a/Commands/boosterPearks/grantrole/__init__.py
+++ b/Commands/boosterPearks/grantrole/__init__.py
@@ -1,0 +1,31 @@
+import discord
+from db.DBHelper import get_custom_role
+
+async def grantrole(interaction: discord.Interaction, target: discord.Member):
+    booster_id = str(interaction.user.id)
+    target_id = str(target.id)
+
+    if booster_id == target_id:
+        await interaction.response.send_message(
+            "You can't give your role to yourself.", ephemeral=True
+        )
+        return
+
+    role_id = get_custom_role(interaction.guild.id, booster_id)
+    if not role_id:
+        await interaction.response.send_message(
+            "You don't have a custom role.", ephemeral=True
+        )
+        return
+
+    role = interaction.guild.get_role(role_id)
+    if not role:
+        await interaction.response.send_message(
+            "Your custom role was not found.", ephemeral=True
+        )
+        return
+
+    await target.add_roles(role, reason="Booster shared custom role")
+    await interaction.response.send_message(
+        f"✅ {target.display_name} got your role **{role.name}**.", ephemeral=False
+    )

--- a/Commands/funCommands/__init__.py
+++ b/Commands/funCommands/__init__.py
@@ -1,0 +1,3 @@
+from . import punch, stab, good
+
+__all__ = ["punch", "stab", "good"]

--- a/Commands/funCommands/good/__init__.py
+++ b/Commands/funCommands/good/__init__.py
@@ -1,0 +1,36 @@
+import discord
+import requests
+from db.DBHelper import get_role
+from utils import has_role
+
+async def good(interaction: discord.Interaction, user: discord.Member):
+    response = requests.get("https://api.otakugifs.xyz/gif?reaction=pat&format=gif")
+    gif = response.json()["url"]
+    try:
+        sheher_id = get_role(interaction.guild.id, "sheher")
+        hehim_id = get_role(interaction.guild.id, "hehim")
+        if sheher_id and has_role(user, sheher_id) and not user.name == "goodyb":
+            embed = discord.Embed(
+                title=f"{interaction.user.display_name} calls {user.display_name} a good girl",
+                color=discord.Color.red(),
+            )
+            embed.set_image(url=gif)
+            await interaction.response.send_message(embed=embed)
+        elif hehim_id and has_role(user, hehim_id):
+            embed = discord.Embed(
+                title=f"{interaction.user.display_name} calls {user.display_name} a good boy",
+                color=discord.Color.red(),
+            )
+            embed.set_image(url=gif)
+            await interaction.response.send_message(embed=embed)
+        else:
+            embed = discord.Embed(
+                title=f"{interaction.user.display_name} calls {user.display_name} a good child",
+                color=discord.Color.red(),
+            )
+            embed.set_image(url=gif)
+            await interaction.response.send_message(embed=embed)
+    except Exception:
+        await interaction.response.send_message(
+            "Command didnt work, sry :(", ephemeral=True
+        )

--- a/Commands/funCommands/punch/__init__.py
+++ b/Commands/funCommands/punch/__init__.py
@@ -1,0 +1,17 @@
+import discord
+import requests
+
+async def punch(interaction: discord.Interaction, user: discord.Member):
+    response = requests.get("https://api.otakugifs.xyz/gif?reaction=punch&format=gif")
+    gif = response.json()["url"]
+    if user.id == interaction.user.id:
+        await interaction.response.send_message(
+            "You can't punch yourself ... or maybe you can?", ephemeral=True
+        )
+        return
+    embed = discord.Embed(
+        title=f"{interaction.user.display_name} punches {user.display_name}!",
+        color=discord.Colour.red(),
+    )
+    embed.set_image(url=gif)
+    await interaction.response.send_message(embed=embed)

--- a/Commands/funCommands/stab/__init__.py
+++ b/Commands/funCommands/stab/__init__.py
@@ -1,0 +1,74 @@
+import discord
+from random import choice, random
+
+async def stab(interaction: discord.Interaction, user: discord.Member):
+    special_gifs = [
+        "https://i.pinimg.com/originals/15/dd/94/15dd945571c75b2a0f5141c313fb7dc6.gif",
+        "https://i.gifer.com/E65z.gif",
+        "https://i.makeagif.com/media/12-15-2017/I2zZ0u.gif",
+        "https://media.tenor.com/2pCPJqG46awAAAAM/yes-adventure-time.gif",
+    ]
+    stab_gifs = [
+        "https://i.gifer.com/EJEW.gif",
+        "https://i.makeagif.com/media/9-04-2024/cpYT-t.gif",
+        "https://64.media.tumblr.com/7e2453da9674bcb5b18a2b60795dfa07/6ffe034dc5a009bc-9b/s540x810/8eac80d1085f4d86de5c884ab107e79c6f16fc8c.gif",
+        "https://i.pinimg.com/originals/94/c6/37/94c6374c19b627b3a9101f4f9c0585f7.gif",
+        "https://i.gifer.com/IlQa.gif",
+        "https://i.pinimg.com/originals/dc/ac/b2/dcacb261a7ed5b4f368134795017b12f.gif",
+        "https://64.media.tumblr.com/tumblr_m7df09awmi1qbvovho1_500.gif",
+        "https://i.imgur.com/S0TeWYF.gif",
+        "https://i.makeagif.com/media/11-05-2023/mFVJ4J.gif",
+        "https://pa1.aminoapps.com/6253/6fce33471439acfba14932815cc111d617d1ccc4_hq.gif",
+        "https://64.media.tumblr.com/71996944f95f102c6bedc0191d8935d3/16b46dc7e02ca5dd-6d/s500x750/bbaee60ca59a9b5baea445b6440bd77e6f93f9c3.gif",
+        "https://giffiles.alphacoders.com/732/73287.gif",
+        "https://gifdb.com/images/high/haruhi-ryoko-asakura-stabbing-kyon-wv9iij0gq6khu6px.gif",
+        "https://gifdb.com/images/high/kill-sekai-saionji-school-days-stabbing-anime-br2876uawee0jzus.gif",
+        "https://gifdb.com/images/high/black-butler-stab-7n1xy2127wzi18sk.gif",
+        "https://i.gyazo.com/1fdb81ac3ebfb2dee9af9b4127760b70.gif",
+        "https://pa1.aminoapps.com/5765/b867c3725e281743e173dc86340c76733281d07f_hq.gif",
+        "https://64.media.tumblr.com/003a4f007486f7963f29edcc454425d4/4ff62cb12f9f72e0-51/s540x810/3cb10ed0bdd781a9b5b0864e833f448ece0efed2.gif",
+        "https://i.gifer.com/GeUx.gif",
+        "https://i.makeagif.com/media/7-19-2018/NFSY1t.gif",
+        "https://i.makeagif.com/media/4-17-2015/ba-nRJ.gif",
+        "https://i.makeagif.com/media/11-12-2023/a3YlZs.gif",
+        "https://i.redd.it/rq7v0ky0q9wb1.gif",
+        "https://i.imgur.com/HifpF82.gif",
+        "https://i.makeagif.com/media/11-18-2022/Ezac_n.gif",
+        "https://c.tenor.com/uc9Qh0p1mOIAAAAC/yuno-gasai-mirai-nikki.gif",
+    ]
+    sender_id = interaction.user.id
+    try:
+        if user.id == sender_id:
+            if random() < 0.30 or user.id == 756537363509018736:
+                selected_gif = choice(special_gifs)
+                embed = discord.Embed(
+                    title=f"{interaction.user.display_name} tried to stab themselves... and succeeded?!",
+                    color=discord.Color.red(),
+                )
+                embed.set_image(url=selected_gif)
+                await interaction.response.send_message(embed=embed)
+                return
+            else:
+                await interaction.response.send_message(
+                    "You can't stab yourself... or can you?", ephemeral=True
+                )
+                return
+        if random() < 0.75 or user.id == 756537363509018736:
+            gif_url = choice(stab_gifs)
+            embed = discord.Embed(
+                title=f"{interaction.user.display_name} stabs {user.display_name}!",
+                color=discord.Color.red(),
+            )
+            embed.set_image(url=gif_url)
+            await interaction.response.send_message(embed=embed)
+        else:
+            fail_messages = [
+                "Isn't that illegal?",
+                "You don't have a knife.",
+                "You missed completely!",
+            ]
+            await interaction.response.send_message(choice(fail_messages))
+    except Exception:
+        await interaction.response.send_message(
+            "You can't stab someone with higher permission than me.", ephemeral=True
+        )

--- a/bot_instance.py
+++ b/bot_instance.py
@@ -1,0 +1,9 @@
+import discord
+from discord.ext import commands
+
+intents = discord.Intents.default()
+intents.message_content = True
+intents.guilds = True
+intents.members = True
+
+bot = commands.Bot(command_prefix="!", intents=intents)

--- a/command_loader.py
+++ b/command_loader.py
@@ -1,0 +1,43 @@
+from dotenv import load_dotenv
+import os
+import discord
+from discord import app_commands
+from discord.app_commands import cooldown
+from bot_instance import bot
+from Commands.boosterPearks import customRole, grantrole
+from Commands.funCommands import punch, stab, good
+
+load_dotenv(dotenv_path=".env")
+token = os.getenv("bot_token")
+
+@bot.tree.command(name="customrole", description="Create or update your booster role")
+@app_commands.describe(name="Name of your role", color="Hex color like #FFAA00")
+@cooldown(rate=1, per=2.0, key=lambda i: i.user.id)
+async def customroleCommand(interaction: discord.Interaction, name: str, color: str):
+    await customRole.customrole(interaction=interaction, name=name, color=color)
+
+@bot.tree.command(
+    name="grantrole",
+    description="Give your custom role to another user",
+)
+@app_commands.describe(target="User to give your custom role to")
+@cooldown(rate=1, per=2.0, key=lambda i: i.user.id)
+async def grantroleCommand(interaction: discord.Interaction, target: discord.Member):
+    await grantrole.grantrole(interaction=interaction, target=target)
+
+@cooldown(rate=1, per=2.0, key=lambda i: i.user.id)
+@bot.tree.command(name="punch", description="Punch someone with anime style")
+async def punchCommand(interaction: discord.Interaction, user: discord.Member):
+    await punch.punch(interaction=interaction, user=user)
+
+@cooldown(rate=1, per=2.0, key=lambda i: i.user.id)
+@bot.tree.command(name="stab", description="Stab someone with anime style")
+async def stabCommand(interaction: discord.Interaction, user: discord.Member):
+    await stab.stab(interaction=interaction, user=user)
+
+@cooldown(rate=1, per=2.0, key=lambda i: i.user.id)
+@bot.tree.command(name="good", description="Tell someone they are a good boy/girl")
+async def goodCommand(interaction: discord.Interaction, user: discord.Member):
+    await good.good(interaction=interaction, user=user)
+
+bot.run(token)


### PR DESCRIPTION
## Summary
- restructure booster and fun commands into separate modules
- add centralized loader registering commands individually

## Testing
- `python -m py_compile Commands/boosterPearks/customRole/__init__.py Commands/boosterPearks/grantrole/__init__.py Commands/funCommands/punch/__init__.py Commands/funCommands/stab/__init__.py Commands/funCommands/good/__init__.py command_loader.py bot_instance.py`


------
https://chatgpt.com/codex/tasks/task_e_68b97e5a3f488327aab0333815cb5d8f