### PR TITLE
Add prefix support for action economy commands

### DIFF
--- a/commands/action_commands.py
+++ b/commands/action_commands.py
@@ -17,138 +17,181 @@ fight_cooldowns: dict[int, datetime] = {}
 steal_cooldowns: dict[int, datetime] = {}
 
 
+async def _respond(
+    ctx: commands.Context,
+    *,
+    content: str | None = None,
+    embed: discord.Embed | None = None,
+    ephemeral: bool = False,
+) -> None:
+    """Send a response for both prefix and slash command invocations."""
+
+    if ctx.interaction:
+        interaction = ctx.interaction
+        if interaction.response.is_done():
+            await interaction.followup.send(content=content, embed=embed, ephemeral=ephemeral)
+        else:
+            await interaction.response.send_message(
+                content=content, embed=embed, ephemeral=ephemeral
+            )
+        return
+
+    send_kwargs = {}
+    if content is not None:
+        send_kwargs["content"] = content
+    if embed is not None:
+        send_kwargs["embed"] = embed
+    await ctx.send(**send_kwargs)
+
+
 def setup(bot: commands.Bot):
-    @bot.tree.command(
+    @bot.hybrid_command(
         name="steal",
         description="Attempt to steal coins from another user (needs stealth \u2265 3)",
     )
-    async def steal(interaction: discord.Interaction, target: discord.Member):
-        if target.id == interaction.user.id:
-            await interaction.response.send_message(
-                "You can't steal from yourself!", ephemeral=True
-            )
+    @app_commands.describe(target="Member to steal from")
+    async def steal(ctx: commands.Context, target: discord.Member):
+        if target.id == ctx.author.id:
+            await _respond(ctx, content="You can't steal from yourself!", ephemeral=True)
             return
-        uid, tid = str(interaction.user.id), str(target.id)
+        uid, tid = str(ctx.author.id), str(target.id)
         now = datetime.utcnow()
-        cooldown = steal_cooldowns.get(interaction.user.id)
+        cooldown = steal_cooldowns.get(ctx.author.id)
         if cooldown and now - cooldown < timedelta(minutes=45):
             remaining = timedelta(minutes=45) - (now - cooldown)
             minutes, seconds = divmod(int(remaining.total_seconds()), 60)
-            await interaction.response.send_message(
-                f"\u23f3 You can steal again in **{minutes} minutes {seconds} seconds**.",
+            await _respond(
+                ctx,
+                content=f"\u23f3 You can steal again in **{minutes} minutes {seconds} seconds**.",
                 ephemeral=True,
             )
             return
-        register_user(uid, interaction.user.display_name)
+        register_user(uid, ctx.author.display_name)
         register_user(tid, target.display_name)
         actor_stats = get_stats(uid)
         target_stats = get_stats(tid)
         if actor_stats["stealth"] < 3:
-            await interaction.response.send_message(
-                "You need at least **3** Stealth to attempt a steal.", ephemeral=True
+            await _respond(
+                ctx,
+                content="You need at least **3** Stealth to attempt a steal.",
+                ephemeral=True,
             )
             return
         actor_stealth, target_stealth = actor_stats["stealth"], target_stats["stealth"]
         success_chance = actor_stealth / (actor_stealth + target_stealth)
         if random() > success_chance:
-            await interaction.response.send_message(
-                "\U0001f440 You were caught and failed to steal any coins!",
+            await _respond(
+                ctx,
+                content="\U0001f440 You were caught and failed to steal any coins!",
                 ephemeral=True,
             )
             return
         target_balance = get_money(tid)
         if target_balance < 5:
-            await interaction.response.send_message(
-                "Target is too poor to bother...", ephemeral=True
-            )
+            await _respond(ctx, content="Target is too poor to bother...", ephemeral=True)
             return
         max_pct = min(0.05 + 0.02 * max(actor_stealth - target_stealth, 0), 0.25)
         stolen_pct = random() * max_pct
         stolen_amt = max(1, int(target_balance * stolen_pct))
         set_money(tid, target_balance - stolen_amt)
         safe_add_coins(uid, stolen_amt)
-        steal_cooldowns[interaction.user.id] = datetime.utcnow()
-        await interaction.response.send_message(
-            f"\U0001f576\ufe0f Success! You stole **{stolen_amt}** coins from {target.display_name}.",
+        steal_cooldowns[ctx.author.id] = datetime.utcnow()
+        await _respond(
+            ctx,
+            content=(
+                f"\U0001f576\ufe0f Success! You stole **{stolen_amt}** coins from {target.display_name}."
+            ),
             ephemeral=True,
         )
 
-    @bot.tree.command(
-        name="hack",
-        description="Hack the bank to win coins (needs intelligence \u2265 3)",
+    @bot.hybrid_command(
+        name="hack", description="Hack the bank to win coins (needs intelligence \u2265 3)"
     )
-    async def hack(interaction: discord.Interaction):
-        uid = str(interaction.user.id)
-        register_user(uid, interaction.user.display_name)
+    async def hack(ctx: commands.Context):
+        uid = str(ctx.author.id)
+        register_user(uid, ctx.author.display_name)
         now = datetime.utcnow()
-        cooldown = hack_cooldowns.get(interaction.user.id)
+        cooldown = hack_cooldowns.get(ctx.author.id)
         if cooldown and now - cooldown < timedelta(minutes=45):
             remaining = timedelta(minutes=45) - (now - cooldown)
             minutes, seconds = divmod(int(remaining.total_seconds()), 60)
-            await interaction.response.send_message(
-                f"\u23f3 You can hack again in **{minutes} minutes {seconds} seconds**.",
+            await _respond(
+                ctx,
+                content=f"\u23f3 You can hack again in **{minutes} minutes {seconds} seconds**.",
                 ephemeral=True,
             )
             return
         stats = get_stats(uid)
         if stats["intelligence"] < 3:
-            await interaction.response.send_message(
-                "\u274c You need at least **3** Intelligence to attempt a hack.",
+            await _respond(
+                ctx,
+                content="\u274c You need at least **3** Intelligence to attempt a hack.",
                 ephemeral=True,
             )
             return
         int_level = stats["intelligence"]
         success = random() < min(0.20 + 0.05 * (int_level - 3), 0.80)
-        hack_cooldowns[interaction.user.id] = now
+        hack_cooldowns[ctx.author.id] = now
         if not success:
             loss = randint(1, 5) * int_level
             new_bal = max(0, get_money(uid) - loss)
             set_money(uid, new_bal)
-            await interaction.response.send_message(
-                f"\U0001f4bb Hack failed! Security traced you and you lost **{loss}** coins.",
+            await _respond(
+                ctx,
+                content=(
+                    f"\U0001f4bb Hack failed! Security traced you and you lost **{loss}** coins."
+                ),
                 ephemeral=True,
             )
             return
         reward = randint(5, 12) * int_level
         added = safe_add_coins(uid, reward)
         if added > 0:
-            await interaction.response.send_message(
-                f"\U0001f50b Hack successful! You siphoned **{added}** coins from the bank.",
+            await _respond(
+                ctx,
+                content=(
+                    f"\U0001f50b Hack successful! You siphoned **{added}** coins from the bank."
+                ),
                 ephemeral=True,
             )
         else:
-            await interaction.response.send_message(
-                "\u26a0\ufe0f Hack succeeded but server coin limit reached. No coins added.",
+            await _respond(
+                ctx,
+                content=(
+                    "\u26a0\ufe0f Hack succeeded but server coin limit reached. No coins added."
+                ),
                 ephemeral=True,
             )
 
-    @bot.tree.command(
+    @bot.hybrid_command(
         name="fight", description="Fight someone for coins (needs strength \u2265 3)"
     )
-    async def fight(interaction: discord.Interaction, target: discord.Member):
-        if target.id == interaction.user.id:
-            await interaction.response.send_message(
-                "You can't fight yourself!", ephemeral=True
-            )
+    @app_commands.describe(target="Member to fight")
+    async def fight(ctx: commands.Context, target: discord.Member):
+        if target.id == ctx.author.id:
+            await _respond(ctx, content="You can't fight yourself!", ephemeral=True)
             return
-        uid, tid = str(interaction.user.id), str(target.id)
+        uid, tid = str(ctx.author.id), str(target.id)
         now = datetime.utcnow()
-        cooldown = fight_cooldowns.get(interaction.user.id)
+        cooldown = fight_cooldowns.get(ctx.author.id)
         if cooldown and now - cooldown < timedelta(minutes=45):
             remaining = timedelta(minutes=45) - (now - cooldown)
             minutes, seconds = divmod(int(remaining.total_seconds()), 60)
-            await interaction.response.send_message(
-                f"\u23f3 You can fight again in **{minutes} minutes {seconds} seconds**.",
+            await _respond(
+                ctx,
+                content=f"\u23f3 You can fight again in **{minutes} minutes {seconds} seconds**.",
                 ephemeral=True,
             )
             return
-        register_user(uid, interaction.user.display_name)
+        register_user(uid, ctx.author.display_name)
         register_user(tid, target.display_name)
         atk = get_stats(uid)
         defn = get_stats(tid)
         if atk["strength"] < 3:
-            await interaction.response.send_message(
-                "You need at least **3** Strength to start a fight.", ephemeral=True
+            await _respond(
+                ctx,
+                content="You need at least **3** Strength to start a fight.",
+                ephemeral=True,
             )
             return
         atk_str, def_str = atk["strength"], defn["strength"]
@@ -157,8 +200,11 @@ def setup(bot: commands.Bot):
             penalty = max(1, int(get_money(uid) * 0.10))
             set_money(uid, get_money(uid) - penalty)
             safe_add_coins(tid, penalty)
-            await interaction.response.send_message(
-                f"\U0001f3cb\ufe0f You lost the fight and paid **{penalty}** coins in damages to {target.display_name}.",
+            await _respond(
+                ctx,
+                content=(
+                    f"\U0001f3cb\ufe0f You lost the fight and paid **{penalty}** coins in damages to {target.display_name}."
+                ),
                 ephemeral=True,
             )
             return
@@ -167,9 +213,12 @@ def setup(bot: commands.Bot):
         stolen = max(1, int(target_coins * steal_pct))
         set_money(tid, target_coins - stolen)
         safe_add_coins(uid, stolen)
-        fight_cooldowns[interaction.user.id] = datetime.utcnow()
-        await interaction.response.send_message(
-            f"\U0001f4aa Victory! You took **{stolen}** coins from {target.display_name}.",
+        fight_cooldowns[ctx.author.id] = datetime.utcnow()
+        await _respond(
+            ctx,
+            content=(
+                f"\U0001f4aa Victory! You took **{stolen}** coins from {target.display_name}."
+            ),
             ephemeral=True,
         )
 


### PR DESCRIPTION
## Summary
- convert the steal, hack, and fight actions into hybrid commands so they work with both slash commands and the new `!` prefix
- add a shared response helper to reply correctly whether the command was invoked via prefix or slash

## Testing
- python -m compileall commands/action_commands.py

------
https://chatgpt.com/codex/tasks/task_e_68d66cf543b88327bcf9a5645dcd9b5e