### PR TITLE
Add prefix support across all commands

### DIFF
--- a/commands/action_commands.py
+++ b/commands/action_commands.py
@@ -11,6 +11,7 @@ from db.DBHelper import (
     set_money,
     safe_add_coins,
 )
+from .hybrid_helpers import respond
 
 hack_cooldowns: dict[int, datetime] = {}
 fight_cooldowns: dict[int, datetime] = {}
@@ -18,137 +19,153 @@ steal_cooldowns: dict[int, datetime] = {}
 
 
 def setup(bot: commands.Bot):
-    @bot.tree.command(
+    @bot.hybrid_command(
         name="steal",
         description="Attempt to steal coins from another user (needs stealth \u2265 3)",
     )
-    async def steal(interaction: discord.Interaction, target: discord.Member):
-        if target.id == interaction.user.id:
-            await interaction.response.send_message(
-                "You can't steal from yourself!", ephemeral=True
-            )
+    @app_commands.describe(target="Member to steal from")
+    async def steal(ctx: commands.Context, target: discord.Member):
+        if target.id == ctx.author.id:
+            await respond(ctx, content="You can't steal from yourself!", ephemeral=True)
             return
-        uid, tid = str(interaction.user.id), str(target.id)
+        uid, tid = str(ctx.author.id), str(target.id)
         now = datetime.utcnow()
-        cooldown = steal_cooldowns.get(interaction.user.id)
+        cooldown = steal_cooldowns.get(ctx.author.id)
         if cooldown and now - cooldown < timedelta(minutes=45):
             remaining = timedelta(minutes=45) - (now - cooldown)
             minutes, seconds = divmod(int(remaining.total_seconds()), 60)
-            await interaction.response.send_message(
-                f"\u23f3 You can steal again in **{minutes} minutes {seconds} seconds**.",
+            await respond(
+                ctx,
+                content=f"\u23f3 You can steal again in **{minutes} minutes {seconds} seconds**.",
                 ephemeral=True,
             )
             return
-        register_user(uid, interaction.user.display_name)
+        register_user(uid, ctx.author.display_name)
         register_user(tid, target.display_name)
         actor_stats = get_stats(uid)
         target_stats = get_stats(tid)
         if actor_stats["stealth"] < 3:
-            await interaction.response.send_message(
-                "You need at least **3** Stealth to attempt a steal.", ephemeral=True
+            await respond(
+                ctx,
+                content="You need at least **3** Stealth to attempt a steal.",
+                ephemeral=True,
             )
             return
         actor_stealth, target_stealth = actor_stats["stealth"], target_stats["stealth"]
         success_chance = actor_stealth / (actor_stealth + target_stealth)
         if random() > success_chance:
-            await interaction.response.send_message(
-                "\U0001f440 You were caught and failed to steal any coins!",
+            await respond(
+                ctx,
+                content="\U0001f440 You were caught and failed to steal any coins!",
                 ephemeral=True,
             )
             return
         target_balance = get_money(tid)
         if target_balance < 5:
-            await interaction.response.send_message(
-                "Target is too poor to bother...", ephemeral=True
-            )
+            await respond(ctx, content="Target is too poor to bother...", ephemeral=True)
             return
         max_pct = min(0.05 + 0.02 * max(actor_stealth - target_stealth, 0), 0.25)
         stolen_pct = random() * max_pct
         stolen_amt = max(1, int(target_balance * stolen_pct))
         set_money(tid, target_balance - stolen_amt)
         safe_add_coins(uid, stolen_amt)
-        steal_cooldowns[interaction.user.id] = datetime.utcnow()
-        await interaction.response.send_message(
-            f"\U0001f576\ufe0f Success! You stole **{stolen_amt}** coins from {target.display_name}.",
+        steal_cooldowns[ctx.author.id] = datetime.utcnow()
+        await respond(
+            ctx,
+            content=(
+                f"\U0001f576\ufe0f Success! You stole **{stolen_amt}** coins from {target.display_name}."
+            ),
             ephemeral=True,
         )
 
-    @bot.tree.command(
-        name="hack",
-        description="Hack the bank to win coins (needs intelligence \u2265 3)",
+    @bot.hybrid_command(
+        name="hack", description="Hack the bank to win coins (needs intelligence \u2265 3)"
     )
-    async def hack(interaction: discord.Interaction):
-        uid = str(interaction.user.id)
-        register_user(uid, interaction.user.display_name)
+    async def hack(ctx: commands.Context):
+        uid = str(ctx.author.id)
+        register_user(uid, ctx.author.display_name)
         now = datetime.utcnow()
-        cooldown = hack_cooldowns.get(interaction.user.id)
+        cooldown = hack_cooldowns.get(ctx.author.id)
         if cooldown and now - cooldown < timedelta(minutes=45):
             remaining = timedelta(minutes=45) - (now - cooldown)
             minutes, seconds = divmod(int(remaining.total_seconds()), 60)
-            await interaction.response.send_message(
-                f"\u23f3 You can hack again in **{minutes} minutes {seconds} seconds**.",
+            await respond(
+                ctx,
+                content=f"\u23f3 You can hack again in **{minutes} minutes {seconds} seconds**.",
                 ephemeral=True,
             )
             return
         stats = get_stats(uid)
         if stats["intelligence"] < 3:
-            await interaction.response.send_message(
-                "\u274c You need at least **3** Intelligence to attempt a hack.",
+            await respond(
+                ctx,
+                content="\u274c You need at least **3** Intelligence to attempt a hack.",
                 ephemeral=True,
             )
             return
         int_level = stats["intelligence"]
         success = random() < min(0.20 + 0.05 * (int_level - 3), 0.80)
-        hack_cooldowns[interaction.user.id] = now
+        hack_cooldowns[ctx.author.id] = now
         if not success:
             loss = randint(1, 5) * int_level
             new_bal = max(0, get_money(uid) - loss)
             set_money(uid, new_bal)
-            await interaction.response.send_message(
-                f"\U0001f4bb Hack failed! Security traced you and you lost **{loss}** coins.",
+            await respond(
+                ctx,
+                content=(
+                    f"\U0001f4bb Hack failed! Security traced you and you lost **{loss}** coins."
+                ),
                 ephemeral=True,
             )
             return
         reward = randint(5, 12) * int_level
         added = safe_add_coins(uid, reward)
         if added > 0:
-            await interaction.response.send_message(
-                f"\U0001f50b Hack successful! You siphoned **{added}** coins from the bank.",
+            await respond(
+                ctx,
+                content=(
+                    f"\U0001f50b Hack successful! You siphoned **{added}** coins from the bank."
+                ),
                 ephemeral=True,
             )
         else:
-            await interaction.response.send_message(
-                "\u26a0\ufe0f Hack succeeded but server coin limit reached. No coins added.",
+            await respond(
+                ctx,
+                content=(
+                    "\u26a0\ufe0f Hack succeeded but server coin limit reached. No coins added."
+                ),
                 ephemeral=True,
             )
 
-    @bot.tree.command(
+    @bot.hybrid_command(
         name="fight", description="Fight someone for coins (needs strength \u2265 3)"
     )
-    async def fight(interaction: discord.Interaction, target: discord.Member):
-        if target.id == interaction.user.id:
-            await interaction.response.send_message(
-                "You can't fight yourself!", ephemeral=True
-            )
+    @app_commands.describe(target="Member to fight")
+    async def fight(ctx: commands.Context, target: discord.Member):
+        if target.id == ctx.author.id:
+            await respond(ctx, content="You can't fight yourself!", ephemeral=True)
             return
-        uid, tid = str(interaction.user.id), str(target.id)
+        uid, tid = str(ctx.author.id), str(target.id)
         now = datetime.utcnow()
-        cooldown = fight_cooldowns.get(interaction.user.id)
+        cooldown = fight_cooldowns.get(ctx.author.id)
         if cooldown and now - cooldown < timedelta(minutes=45):
             remaining = timedelta(minutes=45) - (now - cooldown)
             minutes, seconds = divmod(int(remaining.total_seconds()), 60)
-            await interaction.response.send_message(
-                f"\u23f3 You can fight again in **{minutes} minutes {seconds} seconds**.",
+            await respond(
+                ctx,
+                content=f"\u23f3 You can fight again in **{minutes} minutes {seconds} seconds**.",
                 ephemeral=True,
             )
             return
-        register_user(uid, interaction.user.display_name)
+        register_user(uid, ctx.author.display_name)
         register_user(tid, target.display_name)
         atk = get_stats(uid)
         defn = get_stats(tid)
         if atk["strength"] < 3:
-            await interaction.response.send_message(
-                "You need at least **3** Strength to start a fight.", ephemeral=True
+            await respond(
+                ctx,
+                content="You need at least **3** Strength to start a fight.",
+                ephemeral=True,
             )
             return
         atk_str, def_str = atk["strength"], defn["strength"]
@@ -157,8 +174,11 @@ def setup(bot: commands.Bot):
             penalty = max(1, int(get_money(uid) * 0.10))
             set_money(uid, get_money(uid) - penalty)
             safe_add_coins(tid, penalty)
-            await interaction.response.send_message(
-                f"\U0001f3cb\ufe0f You lost the fight and paid **{penalty}** coins in damages to {target.display_name}.",
+            await respond(
+                ctx,
+                content=(
+                    f"\U0001f3cb\ufe0f You lost the fight and paid **{penalty}** coins in damages to {target.display_name}."
+                ),
                 ephemeral=True,
             )
             return
@@ -167,9 +187,12 @@ def setup(bot: commands.Bot):
         stolen = max(1, int(target_coins * steal_pct))
         set_money(tid, target_coins - stolen)
         safe_add_coins(uid, stolen)
-        fight_cooldowns[interaction.user.id] = datetime.utcnow()
-        await interaction.response.send_message(
-            f"\U0001f4aa Victory! You took **{stolen}** coins from {target.display_name}.",
+        fight_cooldowns[ctx.author.id] = datetime.utcnow()
+        await respond(
+            ctx,
+            content=(
+                f"\U0001f4aa Victory! You took **{stolen}** coins from {target.display_name}."
+            ),
             ephemeral=True,
         )
 

--- a/commands/admin_commands.py
+++ b/commands/admin_commands.py
@@ -58,6 +58,7 @@ from db.DBHelper import (
     get_anti_nuke_log_channel,
 )
 from utils import has_role, has_command_permission, get_channel_webhook, parse_duration
+from .hybrid_helpers import add_prefix_command
 
 
 async def run_command_tests(bot: commands.Bot) -> dict[str, str]:
@@ -1188,6 +1189,47 @@ def setup(bot: commands.Bot):
         if failed:
             msg += f"\n\u26a0\ufe0f Failed for: {', '.join(failed)}"
         await interaction.response.send_message(msg, ephemeral=True)
+
+    for func, name in (
+        (test_commands, "test"),
+        (setstatpoints, "setstatpoints"),
+        (lastdate, "lastdate"),
+        (setstat, "setstat"),
+        (addshoprole, "addshoprole"),
+        (shop, "shop"),
+        (buyrole, "buyrole"),
+        (chatrevive, "chatrevive"),
+        (managePrisonMember, "manageprisonmember"),
+        (manageViltrumite, "manageviltrumite"),
+        (manageYeager, "manageyeager"),
+        (manageackerman, "manageackerman"),
+        (addcolorreactionrole, "addcolorreactionrole"),
+        (imitate, "imitate"),
+        (giveaway, "giveaway"),
+        (lock_channel, "lock"),
+        (unlock_channel, "unlock"),
+        (addfilterword, "addfilterword"),
+        (removefilterword, "removefilterword"),
+        (filterwords, "filterwords"),
+        (addtrigger, "addtrigger"),
+        (removetrigger, "removetrigger"),
+        (removetriggerresponse, "removetriggerresponse"),
+        (triggers, "triggers"),
+        (setwelcomechannel, "setwelcomechannel"),
+        (setleavechannel, "setleavechannel"),
+        (setwelcomemsg, "setwelcomemsg"),
+        (setleavemsg, "setleavemsg"),
+        (setboostchannel, "setboostchannel"),
+        (setboostmsg, "setboostmsg"),
+        (setlogchannel, "setlogchannel"),
+        (serversettings, "serversettings"),
+        (setrole, "setrole"),
+        (removerole, "removerole"),
+        (setcommandrole, "setcommandrole"),
+        (removecommandrole, "removecommandrole"),
+        (createrole, "createrole"),
+    ):
+        add_prefix_command(bot, func, name=name)
 
     return (
         setstatpoints,

--- a/commands/antinuke_commands.py
+++ b/commands/antinuke_commands.py
@@ -4,6 +4,7 @@ from discord.ext import commands
 from typing import Optional
 
 from utils import parse_duration
+from .hybrid_helpers import add_prefix_command
 from db.DBHelper import (
     set_anti_nuke_setting,
     get_anti_nuke_setting,
@@ -122,4 +123,10 @@ def setup(bot: commands.Bot):
         lines.append(f"Safe roles: {', '.join(roles)}")
         lines.append(f"Log channel: {log_line}")
         await interaction.response.send_message("\n".join(lines), ephemeral=True)
+
+    add_prefix_command(bot, antinukeconfig)
+    add_prefix_command(bot, antinukeignoreuser)
+    add_prefix_command(bot, antinukeignorerole)
+    add_prefix_command(bot, antinukelog)
+    add_prefix_command(bot, antinukesettings)
 

--- a/commands/booster_commands.py
+++ b/commands/booster_commands.py
@@ -2,6 +2,7 @@ import discord
 from discord import app_commands
 from discord.ext import commands
 from db.DBHelper import get_custom_role, set_custom_role
+from .hybrid_helpers import add_prefix_command
 
 
 def setup(bot: commands.Bot):
@@ -83,5 +84,8 @@ def setup(bot: commands.Bot):
         await interaction.response.send_message(
             f"✅ {target.display_name} got your role **{role.name}**.", ephemeral=False
         )
+
+    add_prefix_command(bot, customrole)
+    add_prefix_command(bot, grantrole)
 
     return customrole, grantrole

--- a/commands/economy_commands.py
+++ b/commands/economy_commands.py
@@ -137,6 +137,7 @@ from db.DBHelper import (
     set_anime_title,
 )
 from utils import has_command_permission
+from .hybrid_helpers import add_prefix_command
 
 
 class RequestView(ui.View):
@@ -933,6 +934,25 @@ def setup(bot: commands.Bot):
         view.players[interaction.user.id] = interaction.user.display_name
         await interaction.response.send_message(view.render(), view=view)
         view.message = await interaction.original_response()
+
+    for command in (
+        money,
+        balance,
+        give,
+        remove,
+        donate,
+        request,
+        topcoins,
+        weekly,
+        daily,
+        superpower,
+        gamble,
+        casino,
+        duel,
+        blackjack,
+        poker,
+    ):
+        add_prefix_command(bot, command)
 
     return (
         money,

--- a/commands/explain_commands.py
+++ b/commands/explain_commands.py
@@ -3,6 +3,7 @@ from discord import app_commands
 from discord.ext import commands
 
 from db.DBHelper import get_command_permission
+from .hybrid_helpers import add_prefix_command
 
 # Custom explanations for commands. Add entries here to provide
 # longer or more detailed descriptions than the default command
@@ -245,6 +246,8 @@ def setup(bot: commands.Bot):
             f"**Required Role:** {role_mention}",
             ephemeral=True,
         )
+
+    add_prefix_command(bot, explain)
 
     @explain.autocomplete("command")
     async def explain_autocomplete(

--- a/commands/fun_commands.py
+++ b/commands/fun_commands.py
@@ -4,58 +4,64 @@ from discord.ext import commands
 from random import choice, random
 from typing import Optional
 from collections import defaultdict
-from db.DBHelper import get_role
-from utils import has_role, get_channel_webhook, has_command_permission
 import requests
+
+from db.DBHelper import get_role
+from utils import has_role
+
+from .hybrid_helpers import respond
 
 lowercase_locked: dict[int, set[int]] = defaultdict(set)
 
 
 def setup(bot: commands.Bot):
-    @bot.tree.command(
+    @bot.hybrid_command(
         name="forcelowercase",
         description="Force a member's messages to lowercase (toggle)",
     )
     @app_commands.describe(member="Member to lock/unlock")
+    @commands.has_permissions(manage_messages=True)
     @app_commands.checks.has_permissions(manage_messages=True)
-    async def forcelowercase(interaction: discord.Interaction, member: discord.Member):
-        locked = lowercase_locked[interaction.guild.id]
+    async def forcelowercase(ctx: commands.Context, member: discord.Member):
+        if not ctx.guild:
+            await respond(ctx, content="This command can only be used in a server.", ephemeral=True)
+            return
+        locked = lowercase_locked[ctx.guild.id]
         if member.id in locked:
             locked.remove(member.id)
-            await interaction.response.send_message(
-                f"🔓 {member.display_name} unlocked – messages stay unchanged.",
+            await respond(
+                ctx,
+                content=f"🔓 {member.display_name} unlocked – messages stay unchanged.",
                 ephemeral=True,
             )
         else:
             locked.add(member.id)
-            await interaction.response.send_message(
-                f"🔒 {member.display_name} locked – messages will be lower-cased.",
+            await respond(
+                ctx,
+                content=f"🔒 {member.display_name} locked – messages will be lower-cased.",
                 ephemeral=True,
             )
 
-    @bot.tree.command(name="punch", description="Punch someone with anime style")
-    async def punch(interaction: discord.Interaction, user: discord.Member):
+    @bot.hybrid_command(name="punch", description="Punch someone with anime style")
+    async def punch(ctx: commands.Context, user: discord.Member):
         response = requests.get(
             "https://api.otakugifs.xyz/gif?reaction=punch&format=gif"
         )
-
-        gif = response.json()
-        gif = gif["url"]
-        if user.id == interaction.user.id:
-            await interaction.response.send_message(
-                "You can't punch yourself ... or maybe you can?", ephemeral=True
+        gif = response.json()["url"]
+        if user.id == ctx.author.id:
+            await respond(
+                ctx, content="You can't punch yourself ... or maybe you can?", ephemeral=True
             )
             return
-
         embed = discord.Embed(
-            title=f"{interaction.user.display_name} punches {user.display_name}!",
+            title=f"{ctx.author.display_name} punches {user.display_name}!",
             color=discord.Colour.red(),
         )
         embed.set_image(url=gif)
-        await interaction.response.send_message(embed=embed)
+        await respond(ctx, embed=embed)
 
-    @bot.tree.command(name="stab", description="Stab someone with anime style")
-    async def stab(interaction: discord.Interaction, user: discord.Member):
+    @bot.hybrid_command(name="stab", description="Stab someone with anime style")
+    async def stab(ctx: commands.Context, user: discord.Member):
         special_gifs = [
             "https://i.pinimg.com/originals/15/dd/94/15dd945571c75b2a0f5141c313fb7dc6.gif",
             "https://i.gifer.com/E65z.gif",
@@ -90,288 +96,244 @@ def setup(bot: commands.Bot):
             "https://i.makeagif.com/media/11-18-2022/Ezac_n.gif",
             "https://c.tenor.com/uc9Qh0p1mOIAAAAC/yuno-gasai-mirai-nikki.gif",
         ]
-        sender_id = interaction.user.id
+        sender_id = ctx.author.id
         try:
             if user.id == sender_id:
                 if random() < 0.30 or user.id == 756537363509018736:
                     selected_gif = choice(special_gifs)
                     embed = discord.Embed(
-                        title=f"{interaction.user.display_name} tried to stab themselves... and succeeded?!",
+                        title=f"{ctx.author.display_name} tried to stab themselves... and succeeded?!",
                         color=discord.Color.red(),
                     )
                     embed.set_image(url=selected_gif)
-                    await interaction.response.send_message(embed=embed)
+                    await respond(ctx, embed=embed)
                     return
-                else:
-                    await interaction.response.send_message(
-                        "You can't stab yourself... or can you?", ephemeral=True
-                    )
-                    return
+                await respond(ctx, content="You can't stab yourself... or can you?", ephemeral=True)
+                return
             if random() < 0.75 or user.id == 756537363509018736:
                 gif_url = choice(stab_gifs)
                 embed = discord.Embed(
-                    title=f"{interaction.user.display_name} stabs {user.display_name}!",
+                    title=f"{ctx.author.display_name} stabs {user.display_name}!",
                     color=discord.Color.red(),
                 )
                 embed.set_image(url=gif_url)
-                await interaction.response.send_message(embed=embed)
+                await respond(ctx, embed=embed)
             else:
                 fail_messages = [
                     "Isn't that illegal?",
                     "You don't have a knife.",
                     "You missed completely!",
                 ]
-                await interaction.response.send_message(choice(fail_messages))
+                await respond(ctx, content=choice(fail_messages))
         except Exception:
-            await interaction.response.send_message(
-                "You can't stab someone with higher permission than me.", ephemeral=True
+            await respond(
+                ctx,
+                content="You can't stab someone with higher permission than me.",
+                ephemeral=True,
             )
 
-    @bot.tree.command(name="goon", description="goon to someone on the server")
-    async def goon(interaction: discord.Interaction, user: discord.Member):
+    @bot.hybrid_command(name="goon", description="goon to someone on the server")
+    async def goon(ctx: commands.Context, user: discord.Member):
         die_gifs = [
             "https://images-ext-1.discordapp.net/external/NsMNJnl7MWCPxMK2Q-MdPdUApR3VX8-nxpDFhdWl7PI/https/media.tenor.com/wQZWGLcXSgYAAAPo/you-died-link.gif"
         ]
         goon_gifs = [
             "https://images-ext-1.discordapp.net/external/aFNUqz7T07oOHvYQG1_DRBccPglRx_nRzshRGe0NDW8/https/media.tenor.com/LYFIesZUNiEAAAPo/lebron-james-lebron.gif"
         ]
-        if user.id == interaction.user.id:
-            await interaction.response.send_message(
-                "You cant goon to yourself", ephemeral=True
-            )
+        if user.id == ctx.author.id:
+            await respond(ctx, content="You cant goon to yourself", ephemeral=True)
             return
         if random() < 0.95:
             gif_url = choice(goon_gifs)
             embed = discord.Embed(
-                title=f"{interaction.user.display_name} goons to {user.display_name}!",
+                title=f"{ctx.author.display_name} goons to {user.display_name}!",
                 color=discord.Color.red(),
             )
             embed.set_image(url=gif_url)
-            await interaction.response.send_message(embed=embed)
+            await respond(ctx, embed=embed)
         else:
             gif_url = choice(die_gifs)
             embed = discord.Embed(
-                title=f"{interaction.user.display_name} dies because of gooning!",
+                title=f"{ctx.author.display_name} dies because of gooning!",
                 color=discord.Color.red(),
             )
             embed.set_image(url=gif_url)
-            await interaction.response.send_message(embed=embed)
+            await respond(ctx, embed=embed)
 
-    @bot.tree.command(name="dance", description="hit a cool dance")
-    async def dance(interaction: discord.Interaction):
+    @bot.hybrid_command(name="dance", description="hit a cool dance")
+    async def dance(ctx: commands.Context):
         response = requests.get(
             "https://api.otakugifs.xyz/gif?reaction=dance&format=gif"
         )
-
-        gif = response.json()
-        gif = gif["url"]
+        gif = response.json()["url"]
         embed = discord.Embed(
-            title=f"{interaction.user.display_name} Dances", color=discord.Color.red()
+            title=f"{ctx.author.display_name} Dances", color=discord.Color.red()
         )
         embed.set_image(url=gif)
-        await interaction.response.send_message(embed=embed)
+        await respond(ctx, embed=embed)
 
-    @bot.tree.command(name="kiss", description="kiss another user")
-    async def kiss(interaction: discord.Interaction, user: discord.Member):
+    @bot.hybrid_command(name="kiss", description="kiss another user")
+    async def kiss(ctx: commands.Context, user: discord.Member):
         response = requests.get(
             "https://api.otakugifs.xyz/gif?reaction=kiss&format=gif"
         )
-
-        gif = response.json()
-        gif = gif["url"]
+        gif = response.json()["url"]
         embed = discord.Embed(
-            title=f"{interaction.user.display_name} kisses {user.display_name} ꨄ︎",
+            title=f"{ctx.author.display_name} kisses {user.display_name} ꨄ︎",
             color=discord.Color.red(),
         )
         embed.set_image(url=gif)
-        await interaction.response.send_message(embed=embed)
+        await respond(ctx, embed=embed)
 
-    @bot.tree.command(name="blush", description="blush (bcs of another user)")
-    async def blush(interaction: discord.Interaction, user: discord.Member = None):
+    @bot.hybrid_command(name="blush", description="blush (bcs of another user)")
+    async def blush(ctx: commands.Context, user: Optional[discord.Member] = None):
         response = requests.get(
             "https://api.otakugifs.xyz/gif?reaction=blush&format=gif"
         )
-
-        gif = response.json()
-        gif = gif["url"]
-        if user == None:
+        gif = response.json()["url"]
+        if user is None:
             embed = discord.Embed(
-                title=f"{interaction.user.display_name} blushes",
+                title=f"{ctx.author.display_name} blushes",
                 color=discord.Color.red(),
             )
-            embed.set_image(url=gif)
-            await interaction.response.send_message(embed=embed)
         else:
             embed = discord.Embed(
-                title=f"{interaction.user.display_name} blushes because of {user.display_name} ꨄ",
+                title=f"{ctx.author.display_name} blushes because of {user.display_name} ꨄ",
                 color=discord.Color.red(),
             )
-            embed.set_image(url=gif)
-            await interaction.response.send_message(embed=embed)
+        embed.set_image(url=gif)
+        await respond(ctx, embed=embed)
 
-    @bot.tree.command(name="mad", description="be mad (bcs of another user)")
-    async def mad(interaction: discord.Interaction, user: discord.Member = None):
+    @bot.hybrid_command(name="mad", description="be mad (bcs of another user)")
+    async def mad(ctx: commands.Context, user: Optional[discord.Member] = None):
         response = requests.get("https://api.otakugifs.xyz/gif?reaction=mad&format=gif")
-
-        gif = response.json()
-        gif = gif["url"]
-        if user == None:
-            embed = discord.Embed(
-                title=f"{interaction.user.display_name} is mad",
-                color=discord.Color.red(),
-            )
-            embed.set_image(url=gif)
-            await interaction.response.send_message(embed=embed)
+        gif = response.json()["url"]
+        if user is None:
+            title = f"{ctx.author.display_name} is mad"
         else:
-            embed = discord.Embed(
-                title=f"{interaction.user.display_name} is mad because of {user.display_name}",
-                color=discord.Color.red(),
-            )
-            embed.set_image(url=gif)
-            await interaction.response.send_message(embed=embed)
+            title = f"{ctx.author.display_name} is mad because of {user.display_name}"
+        embed = discord.Embed(title=title, color=discord.Color.red())
+        embed.set_image(url=gif)
+        await respond(ctx, embed=embed)
 
-    @bot.tree.command(name="woah", description="woah")
-    async def woah(interaction: discord.Interaction):
+    @bot.hybrid_command(name="woah", description="woah")
+    async def woah(ctx: commands.Context):
         response = requests.get(
             "https://api.otakugifs.xyz/gif?reaction=woah&format=gif"
         )
-
-        gif = response.json()
-        gif = gif["url"]
-
+        gif = response.json()["url"]
         embed = discord.Embed(
-            title=f"{interaction.user.display_name} says woah!",
+            title=f"{ctx.author.display_name} says woah!",
             color=discord.Color.red(),
         )
         embed.set_image(url=gif)
-        await interaction.response.send_message(embed=embed)
+        await respond(ctx, embed=embed)
 
-    @bot.tree.command(name="airkiss", description="send an airkiss to someone")
-    async def airkiss(interaction: discord.Interaction, user: discord.Member):
+    @bot.hybrid_command(name="airkiss", description="send an airkiss to someone")
+    async def airkiss(ctx: commands.Context, user: discord.Member):
         response = requests.get(
             "https://api.otakugifs.xyz/gif?reaction=airkiss&format=gif"
         )
-
-        gif = response.json()
-        gif = gif["url"]
-
+        gif = response.json()["url"]
         embed = discord.Embed(
-            title=f"{interaction.user.display_name} sends an airkiss to {user.display_name} ꨄ",
+            title=f"{ctx.author.display_name} sends an airkiss to {user.display_name} ꨄ",
             color=discord.Color.red(),
         )
         embed.set_image(url=gif)
-        await interaction.response.send_message(embed=embed)
+        await respond(ctx, embed=embed)
 
-    @bot.tree.command(name="yawn", description="yawn")
-    async def yawn(interaction: discord.Interaction):
+    @bot.hybrid_command(name="yawn", description="yawn")
+    async def yawn(ctx: commands.Context):
         response = requests.get(
             "https://api.otakugifs.xyz/gif?reaction=yawn&format=gif"
         )
-
-        gif = response.json()
-        gif = gif["url"]
-
+        gif = response.json()["url"]
         embed = discord.Embed(
-            title=f"{interaction.user.display_name} yawns!",
+            title=f"{ctx.author.display_name} yawns!",
             color=discord.Color.red(),
         )
         embed.set_image(url=gif)
-        await interaction.response.send_message(embed=embed)
+        await respond(ctx, embed=embed)
 
-    @bot.tree.command(name="tickle", description="tickle another user")
-    async def tickle(interaction: discord.Interaction, user: discord.Member):
+    @bot.hybrid_command(name="tickle", description="tickle another user")
+    async def tickle(ctx: commands.Context, user: discord.Member):
         response = requests.get(
             "https://api.otakugifs.xyz/gif?reaction=tickle&format=gif"
         )
-
-        gif = response.json()
-        gif = gif["url"]
+        gif = response.json()["url"]
         embed = discord.Embed(
-            title=f"{interaction.user.display_name} tickles {user.display_name} ",
+            title=f"{ctx.author.display_name} tickles {user.display_name} ",
             color=discord.Color.red(),
         )
         embed.set_image(url=gif)
-        await interaction.response.send_message(embed=embed)
+        await respond(ctx, embed=embed)
 
-    @bot.tree.command(name="slap", description="slap another user")
-    async def slap(interaction: discord.Interaction, user: discord.Member):
+    @bot.hybrid_command(name="slap", description="slap another user")
+    async def slap(ctx: commands.Context, user: discord.Member):
         try:
             response = requests.get(
                 "https://api.otakugifs.xyz/gif?reaction=slap&format=gif",
                 timeout=5,
             )
             response.raise_for_status()
-            data = response.json()
-            gif = data.get("url", "")
+            gif = response.json().get("url", "")
         except requests.RequestException:
             gif = ""
         embed = discord.Embed(
-            title=f"{interaction.user.display_name} slaps {user.display_name} really hard!",
+            title=f"{ctx.author.display_name} slaps {user.display_name} really hard!",
             color=discord.Color.red(),
         )
         if gif:
             embed.set_image(url=gif)
-        await interaction.response.send_message(
-            embed=embed if gif else None,
-            content=None if gif else "*whiff* Can't fetch a slap gif right now.",
-        )
+            await respond(ctx, embed=embed)
+        else:
+            await respond(
+                ctx,
+                content="*whiff* Can't fetch a slap gif right now.",
+            )
 
-    @bot.tree.command(name="lick", description="Lick another member")
-    async def lick(interaction: discord.Interaction, user: discord.Member):
+    @bot.hybrid_command(name="lick", description="Lick another member")
+    async def lick(ctx: commands.Context, user: discord.Member):
         response = requests.get(
             "https://api.otakugifs.xyz/gif?reaction=lick&format=gif"
         )
-
-        gif = response.json()
-        gif = gif["url"]
+        gif = response.json()["url"]
         embed = discord.Embed(
-            title=f"{interaction.user.display_name} licks {user.display_name} ꨄ︎ how does it taste?",
+            title=f"{ctx.author.display_name} licks {user.display_name} ꨄ︎ how does it taste?",
             color=discord.Color.red(),
         )
         embed.set_image(url=gif)
-        await interaction.response.send_message(embed=embed)
+        await respond(ctx, embed=embed)
 
-    @bot.tree.command(name="good", description="Tell someone he/she is a good boy/girl")
-    async def good(interaction: discord.Interaction, user: discord.Member):
-
+    @bot.hybrid_command(name="good", description="Tell someone he/she is a good boy/girl")
+    async def good(ctx: commands.Context, user: discord.Member):
         response = requests.get("https://api.otakugifs.xyz/gif?reaction=pat&format=gif")
-
-        gif = response.json()
-        gif = gif["url"]
+        gif = response.json()["url"]
         try:
-            sheher_id = get_role(interaction.guild.id, "sheher")
-            hehim_id = get_role(interaction.guild.id, "hehim")
-            if sheher_id and has_role(user, sheher_id) and not user.name == "goodyb":
-                embed = discord.Embed(
-                    title=f"{interaction.user.display_name} calls {user.display_name} a good girl",
-                    color=discord.Color.red(),
-                )
-                embed.set_image(url=gif)
-                await interaction.response.send_message(embed=embed)
+            if not ctx.guild:
+                raise RuntimeError
+            sheher_id = get_role(ctx.guild.id, "sheher")
+            hehim_id = get_role(ctx.guild.id, "hehim")
+            if sheher_id and has_role(user, sheher_id) and user.name != "goodyb":
+                title = f"{ctx.author.display_name} calls {user.display_name} a good girl"
             elif hehim_id and has_role(user, hehim_id):
-                embed = discord.Embed(
-                    title=f"{interaction.user.display_name} calls {user.display_name} a good boy",
-                    color=discord.Color.red(),
-                )
-                embed.set_image(url=gif)
-                await interaction.response.send_message(embed=embed)
+                title = f"{ctx.author.display_name} calls {user.display_name} a good boy"
             else:
-                embed = discord.Embed(
-                    title=f"{interaction.user.display_name} calls {user.display_name} a good child",
-                    color=discord.Color.red(),
-                )
-                embed.set_image(url=gif)
-                await interaction.response.send_message(embed=embed)
+                title = f"{ctx.author.display_name} calls {user.display_name} a good child"
+            embed = discord.Embed(title=title, color=discord.Color.red())
+            embed.set_image(url=gif)
+            await respond(ctx, embed=embed)
         except Exception:
-            await interaction.response.send_message(
-                "Command didnt work, sry :(", ephemeral=True
-            )
+            await respond(ctx, content="Command didnt work, sry :(", ephemeral=True)
 
-    @bot.tree.command(name="getbot", description="Get the bot for your server")
-    async def getbot(interaction: discord.Interaction):
-        await interaction.response.send_message(
-            "This is the developer version of the Clubhallbot, so you can't get this bot for your server. "
-            "BUT there is an official version you can add: https://discord.com/oauth2/authorize?client_id=1401961800504971316&permissions=8&integration_type=0&scope=bot+applications.commands",
+    @bot.hybrid_command(name="getbot", description="Get the bot for your server")
+    async def getbot(ctx: commands.Context):
+        await respond(
+            ctx,
+            content=(
+                "This is the developer version of the Clubhallbot, so you can't get this bot for your server. "
+                "BUT there is an official version you can add: https://discord.com/oauth2/authorize?client_id=1401961800504971316&permissions=8&integration_type=0&scope=bot+applications.commands"
+            ),
             ephemeral=True,
         )
 

--- a/commands/hybrid_helpers.py
+++ b/commands/hybrid_helpers.py
@@ -1,0 +1,217 @@
+import inspect
+import discord
+from discord import app_commands
+from discord.ext import commands
+
+
+class PrefixFollowupAdapter:
+    def __init__(self, ctx: commands.Context):
+        self._ctx = ctx
+
+    async def send(self, *args, **kwargs):
+        return await respond(self._ctx, *args, **kwargs)
+
+
+class PrefixResponseAdapter:
+    def __init__(self, ctx: commands.Context, interaction: "PrefixInteractionAdapter"):
+        self._ctx = ctx
+        self._interaction = interaction
+        self._done = False
+        self._message: discord.Message | None = None
+        self._deferred = False
+        self._deferred_ephemeral = False
+
+    def is_done(self) -> bool:
+        return self._done
+
+    async def send_message(self, *args, **kwargs):
+        if args:
+            raise TypeError("Prefix command adapter only supports keyword arguments")
+        self._done = True
+        self._deferred = False
+        self._message = await respond(self._ctx, **kwargs)
+        return self._message
+
+    async def defer(self, *, thinking: bool = False, ephemeral: bool = False):
+        self._done = True
+        self._deferred = True
+        self._deferred_ephemeral = ephemeral
+        if thinking:
+            self._message = await respond(
+                self._ctx, content="Processing...", ephemeral=ephemeral
+            )
+
+    async def send_modal(self, modal: discord.ui.Modal):
+        self._done = True
+        await respond(
+            self._ctx,
+            content="This action requires the slash command interface. Please use the slash command version instead.",
+            ephemeral=True,
+        )
+
+    async def edit_message(self, *args, **kwargs):
+        if args:
+            raise TypeError("Prefix command adapter only supports keyword arguments")
+        if self._message:
+            await self._message.edit(**kwargs)
+        else:
+            await respond(self._ctx, **kwargs)
+
+    async def edit_original_response(self, *args, **kwargs):
+        if args:
+            raise TypeError("Prefix command adapter only supports keyword arguments")
+        if self._message:
+            await self._message.edit(**kwargs)
+        else:
+            self._message = await respond(
+                self._ctx,
+                ephemeral=self._deferred_ephemeral,
+                **kwargs,
+            )
+        return self._message
+
+    @property
+    def message(self) -> discord.Message | None:
+        return self._message
+
+
+class PrefixInteractionAdapter:
+    def __init__(self, ctx: commands.Context):
+        self._ctx = ctx
+        self.user = ctx.author
+        self.guild = ctx.guild
+        self.channel = ctx.channel
+        self.client = ctx.bot
+        self.response = PrefixResponseAdapter(ctx, self)
+        self.followup = PrefixFollowupAdapter(ctx)
+
+    @property
+    def guild_id(self) -> int | None:
+        return self.guild.id if self.guild else None
+
+    @property
+    def channel_id(self) -> int | None:
+        return self.channel.id if self.channel else None
+
+    async def edit_original_response(self, *args, **kwargs):
+        return await self.response.edit_original_response(*args, **kwargs)
+
+    async def original_response(self) -> discord.Message | None:
+        return self.response.message
+
+
+def add_prefix_command(
+    bot: commands.Bot,
+    func,
+    *,
+    name: str | None = None,
+) -> commands.Command:
+    """Register a prefix equivalent for an app-command callback."""
+
+    sig = inspect.signature(func)
+    params = list(sig.parameters.values())
+    if not params:
+        raise TypeError("Command callback must accept at least an interaction/context parameter")
+    prefix_params = [
+        inspect.Parameter(
+            "ctx",
+            inspect.Parameter.POSITIONAL_OR_KEYWORD,
+            annotation=commands.Context,
+        )
+    ] + params[1:]
+    new_sig = sig.replace(parameters=prefix_params)
+
+    annotations = dict(getattr(func, "__annotations__", {}))
+    annotations.pop(params[0].name, None)
+    annotations["ctx"] = commands.Context
+
+    checks = list(getattr(func, "__discord_app_commands_checks__", []))
+
+    async def wrapper(*args, **kwargs):
+        ctx: commands.Context = args[0]
+        interaction = PrefixInteractionAdapter(ctx)
+        for check in checks:
+            try:
+                result = check(interaction)
+                if inspect.isawaitable(result):
+                    await result
+            except app_commands.AppCommandError as exc:
+                raise commands.CheckFailure(str(exc)) from exc
+        return await func(interaction, *args[1:], **kwargs)
+
+    wrapper.__name__ = f"{func.__name__}_prefix"
+    wrapper.__signature__ = new_sig
+    wrapper.__annotations__ = annotations
+    wrapper.__doc__ = func.__doc__
+
+    return bot.command(name=name or func.__name__)(wrapper)
+
+
+async def respond(
+    ctx: commands.Context,
+    *,
+    content: str | None = None,
+    embed: discord.Embed | None = None,
+    embeds: list[discord.Embed] | None = None,
+    view: discord.ui.View | None = None,
+    file: discord.File | None = None,
+    files: list[discord.File] | None = None,
+    ephemeral: bool = False,
+    allowed_mentions: discord.AllowedMentions | None = None,
+    delete_after: float | None = None,
+) -> discord.Message | None:
+    """Send a response that works for both prefix and slash invocations."""
+
+    interaction = ctx.interaction
+    if interaction:
+        send_kwargs: dict[str, object] = {}
+        if content is not None:
+            send_kwargs["content"] = content
+        if embed is not None:
+            send_kwargs["embed"] = embed
+        if embeds is not None:
+            send_kwargs["embeds"] = embeds
+        if view is not None:
+            send_kwargs["view"] = view
+        if file is not None:
+            send_kwargs["file"] = file
+        if files is not None:
+            send_kwargs["files"] = files
+        if allowed_mentions is not None:
+            send_kwargs["allowed_mentions"] = allowed_mentions
+
+        if interaction.response.is_done():
+            return await interaction.followup.send(
+                **send_kwargs, ephemeral=ephemeral, delete_after=delete_after
+            )
+        else:
+            await interaction.response.send_message(
+                **send_kwargs, ephemeral=ephemeral, delete_after=delete_after
+            )
+            if not interaction.response.is_done():
+                return None
+            try:
+                return await interaction.original_response()
+            except Exception:
+                return None
+        return
+
+    send_kwargs2: dict[str, object] = {}
+    if content is not None:
+        send_kwargs2["content"] = content
+    if embed is not None:
+        send_kwargs2["embed"] = embed
+    if embeds is not None:
+        send_kwargs2["embeds"] = embeds
+    if view is not None:
+        send_kwargs2["view"] = view
+    if file is not None:
+        send_kwargs2["file"] = file
+    if files is not None:
+        send_kwargs2["files"] = files
+    if allowed_mentions is not None:
+        send_kwargs2["allowed_mentions"] = allowed_mentions
+    if delete_after is not None:
+        send_kwargs2["delete_after"] = delete_after
+
+    return await ctx.send(**send_kwargs2)

--- a/commands/setup_wizard.py
+++ b/commands/setup_wizard.py
@@ -22,6 +22,7 @@ from db.DBHelper import (
     add_safe_role,
 )
 from utils import parse_duration
+from .hybrid_helpers import add_prefix_command
 from anti_nuke import CATEGORIES
 
 
@@ -479,3 +480,5 @@ def setup(bot: commands.Bot):
     async def _setup_wizard(interaction: discord.Interaction):
         wizard = SetupWizard(interaction)
         await wizard.start()
+
+    add_prefix_command(bot, _setup_wizard, name="setupwizard")

--- a/commands/stats_commands.py
+++ b/commands/stats_commands.py
@@ -26,6 +26,7 @@ from db.DBHelper import (
     set_money,
 )
 from utils import has_role, has_command_permission, parse_duration
+from .hybrid_helpers import add_prefix_command
 
 
 rod_shop: dict[int, tuple[int, float]] = {}
@@ -390,6 +391,20 @@ def setup(bot: commands.Bot, shop: dict[int, tuple[int, float]]):
             f"📝 Logging messages for {duration}...",
             ephemeral=True,
         )
+
+    for func, name in (
+        (stats_cmd, "stats"),
+        (quest, "quest"),
+        (buypoints, "buypoints"),
+        (allocate, "allocate"),
+        (fish, "fishing"),
+        (buyrod, "buyrod"),
+        (rodshop, "rodshop"),
+        (myrod, "myrod"),
+        (refund, "refund"),
+        (logmessages, "logmessages"),
+    ):
+        add_prefix_command(bot, func, name=name)
 
     return (
         stats_cmd,

--- a/events.py
+++ b/events.py
@@ -281,7 +281,6 @@ async def on_message(
     if message.author.bot:
         return
     update_date(message.author.id, message.author.name)
-    await bot.process_commands(message)
 
 
 async def on_member_join(bot: commands.Bot, member: discord.Member):


### PR DESCRIPTION
## Summary
- add a shared hybrid helper module that adapts slash callbacks for prefix use and centralizes messaging
- update action and fun commands to use the shared responder and register prefix access
- register prefix equivalents for every remaining slash command module via the helper

## Testing
- python -m compileall commands

------
https://chatgpt.com/codex/tasks/task_e_68d66cf543b88327bcf9a5645dcd9b5e