### PR TITLE
Refactor permissions to use static role IDs

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ The script automatically locates `users.db` in the project root so it can be run
 
 Run `/setup-wizard` on your server to walk through a complete configuration.
 The wizard explains every step, lets you skip anything, and sets up channels
-and anti-nuke options. For role shortcuts and command restrictions it points
-you to the `/setrole` and `/setcommandrole` commands for later use.
+and anti-nuke options. Command permissions are now hard-coded via role IDs in
+`permissions.py`, so make sure your staff members have the appropriate roles
+before starting the wizard.
 

--- a/commands/antinuke_commands.py
+++ b/commands/antinuke_commands.py
@@ -3,7 +3,7 @@ from discord import app_commands
 from discord.ext import commands
 from typing import Optional
 
-from utils import parse_duration
+from utils import parse_duration, has_command_permission
 from .hybrid_helpers import add_prefix_command
 from db.DBHelper import (
     set_anti_nuke_setting,
@@ -17,8 +17,6 @@ from db.DBHelper import (
     set_anti_nuke_log_channel,
     get_anti_nuke_log_channel,
 )
-
-OWNER_ID = 756537363509018736
 
 CATEGORIES = [
     "delete_roles",
@@ -48,7 +46,7 @@ def setup(bot: commands.Bot):
         duration: Optional[str],
         enabled: bool,
     ):
-        if interaction.user.id != OWNER_ID:
+        if not has_command_permission(interaction.user, "antinukeconfig", "admin"):
             await interaction.response.send_message("No permission.", ephemeral=True)
             return
         if category not in CATEGORIES:
@@ -62,7 +60,9 @@ def setup(bot: commands.Bot):
 
     @bot.tree.command(name="antinukeignoreuser", description="Toggle safe user")
     async def antinukeignoreuser(interaction: discord.Interaction, user: discord.Member):
-        if interaction.user.id != OWNER_ID:
+        if not has_command_permission(
+            interaction.user, "antinukeignoreuser", "admin"
+        ):
             await interaction.response.send_message("No permission.", ephemeral=True)
             return
         guild_id = interaction.guild.id
@@ -75,7 +75,9 @@ def setup(bot: commands.Bot):
 
     @bot.tree.command(name="antinukeignorerole", description="Toggle safe role")
     async def antinukeignorerole(interaction: discord.Interaction, role: discord.Role):
-        if interaction.user.id != OWNER_ID:
+        if not has_command_permission(
+            interaction.user, "antinukeignorerole", "admin"
+        ):
             await interaction.response.send_message("No permission.", ephemeral=True)
             return
         guild_id = interaction.guild.id
@@ -88,7 +90,7 @@ def setup(bot: commands.Bot):
 
     @bot.tree.command(name="antinukelog", description="Set anti nuke log channel")
     async def antinukelog(interaction: discord.Interaction, channel: discord.TextChannel):
-        if interaction.user.id != OWNER_ID:
+        if not has_command_permission(interaction.user, "antinukelog", "admin"):
             await interaction.response.send_message("No permission.", ephemeral=True)
             return
         set_anti_nuke_log_channel(interaction.guild.id, channel.id)
@@ -98,7 +100,9 @@ def setup(bot: commands.Bot):
 
     @bot.tree.command(name="antinukesettings", description="Show anti nuke configuration")
     async def antinukesettings(interaction: discord.Interaction):
-        if interaction.user.id != OWNER_ID:
+        if not has_command_permission(
+            interaction.user, "antinukesettings", "admin"
+        ):
             await interaction.response.send_message("No permission.", ephemeral=True)
             return
         lines = []

--- a/commands/explain_commands.py
+++ b/commands/explain_commands.py
@@ -2,8 +2,8 @@ import discord
 from discord import app_commands
 from discord.ext import commands
 
-from db.DBHelper import get_command_permission
 from .hybrid_helpers import add_prefix_command
+from permissions import describe_permission
 
 # Custom explanations for commands. Add entries here to provide
 # longer or more detailed descriptions than the default command
@@ -40,7 +40,8 @@ COMMAND_EXPLANATIONS: dict[str, str] = {
     ),
     "lastdate": (
         "Displays the last active date of a specific user. "
-        "Only usable by admins or server boosters. Useful for activity tracking or moderation."
+        "Only usable by members with the moderation role (ID 1380267391598071859). "
+        "Useful for activity tracking or moderation."
     ),
     "setstat": (
         "Sets a specific stat (intelligence, strength, or stealth) to a new value for a user. "
@@ -60,30 +61,30 @@ COMMAND_EXPLANATIONS: dict[str, str] = {
     ),
     "manageprisonmember": (
         "Sends a user to prison (restricting access) or frees them from it. "
-        "You can specify a duration or cancel an existing prison timer. Only for moderators/admins. "
+        "You can specify a duration or cancel an existing prison timer. Only for the moderation role (ID 1380267391598071859). "
         "Useful for soft moderation or fun punishment features."
     ),
     "antinukeconfig": (
         "Configures anti-nuke settings for your server. You choose a category (like delete_roles, kick, ban), "
         "set a threshold (number of actions before punishment), select a punishment (timeout, strip, kick, ban), "
         "optionally set duration (for timeout), and enable or disable the protection. "
-        "Only the server owner can use this command."
+        "Only members with the admin role (ID 1351479405699928108) can use this command."
     ),
     "antinukeignoreuser": (
         "Toggles whether a specific user is marked as safe from anti-nuke checks. "
-        "If the user is already marked safe, they are removed. Only usable by the server owner."
+        "If the user is already marked safe, they are removed. Only usable by the admin role (ID 1351479405699928108)."
     ),
     "antinukeignorerole": (
         "Toggles whether a specific role is marked as safe from anti-nuke checks. "
-        "If the role is already marked safe, it is removed. Only usable by the server owner."
+        "If the role is already marked safe, it is removed. Only usable by the admin role (ID 1351479405699928108)."
     ),
     "antinukelog": (
         "Sets the channel where anti-nuke actions are logged. "
-        "Only the server owner can use this. Important to review automatic punishments."
+        "Only the admin role (ID 1351479405699928108) can use this. Important to review automatic punishments."
     ),
     "antinukesettings": (
         "Displays the current anti-nuke settings and safe users/roles for your server. "
-        "Only the server owner can access this. Helps verify what protections are active."
+        "Only the admin role (ID 1351479405699928108) can access this. Helps verify what protections are active."
     ),
     "customrole": (
         "Creates or updates your personal booster role. "
@@ -132,7 +133,7 @@ COMMAND_EXPLANATIONS: dict[str, str] = {
     ),
     "forcelowercase": (
         "Toggles a setting that forces a specific user's messages to appear in lowercase. "
-        "Only users with 'Manage Messages' permission can use this. It's a fun moderation tool or prank."
+        "Only members with the moderation role (ID 1380267391598071859) can use this. It's a fun moderation tool or prank."
     ),
     "punch": (
         "Sends a random anime-style punch GIF showing you punching another user. "
@@ -171,7 +172,7 @@ COMMAND_EXPLANATIONS: dict[str, str] = {
         "Starts an interactive setup process to configure the server features like welcome messages, "
         "leave messages, booster settings, logging, and anti-nuke. "
         "You will be guided through modals to input channels, messages, roles, and configurations. "
-        "Recommended to run this after adding the bot to your server."
+        "Recommended to run this after adding the bot to your server. Requires the admin role (ID 1351479405699928108)."
     ),
     "dance": (
         "Sends a random anime dance GIF with a fun message. "
@@ -219,15 +220,7 @@ def setup(bot: commands.Bot):
             return
 
         guild = interaction.guild
-        role_mention = "No specific role required"
-        if guild is not None:
-            role_id = get_command_permission(guild.id, command)
-            if role_id is not None:
-                role = guild.get_role(role_id)
-                if role is not None:
-                    role_mention = role.mention
-                else:
-                    role_mention = f"Role ID {role_id}"
+        role_mention = describe_permission(guild, command)
 
         params_lines: list[str] = []
         for param in cmd.parameters:

--- a/commands/fun_commands.py
+++ b/commands/fun_commands.py
@@ -7,7 +7,7 @@ from collections import defaultdict
 import requests
 
 from db.DBHelper import get_role
-from utils import has_role
+from utils import has_role, has_command_permission
 
 from .hybrid_helpers import respond
 
@@ -20,11 +20,12 @@ def setup(bot: commands.Bot):
         description="Force a member's messages to lowercase (toggle)",
     )
     @app_commands.describe(member="Member to lock/unlock")
-    @commands.has_permissions(manage_messages=True)
-    @app_commands.checks.has_permissions(manage_messages=True)
     async def forcelowercase(ctx: commands.Context, member: discord.Member):
         if not ctx.guild:
             await respond(ctx, content="This command can only be used in a server.", ephemeral=True)
+            return
+        if not has_command_permission(ctx.author, "forcelowercase", "mod"):
+            await respond(ctx, content="You don't have permission to use this command.", ephemeral=True)
             return
         locked = lowercase_locked[ctx.guild.id]
         if member.id in locked:

--- a/commands/setup_wizard.py
+++ b/commands/setup_wizard.py
@@ -21,7 +21,7 @@ from db.DBHelper import (
     add_safe_user,
     add_safe_role,
 )
-from utils import parse_duration
+from utils import parse_duration, has_command_permission
 from .hybrid_helpers import add_prefix_command
 from anti_nuke import CATEGORIES
 
@@ -413,7 +413,7 @@ class SetupWizard:
                     "Restrict commands to specific roles.",
                     "Medium",
                     instruction=(
-                        "Use `/setcommandrole <command> <@role>` after the wizard"
+                        "Make sure staff members have the required Discord roles"
                         " to limit command usage."
                     ),
 
@@ -476,8 +476,10 @@ def setup(bot: commands.Bot):
     @bot.tree.command(
         name="setup-wizard", description="Start an interactive setup wizard for this server"
     )
-    @app_commands.checks.has_permissions(manage_guild=True)
     async def _setup_wizard(interaction: discord.Interaction):
+        if not has_command_permission(interaction.user, "setup-wizard", "admin"):
+            await interaction.response.send_message("No permission.", ephemeral=True)
+            return
         wizard = SetupWizard(interaction)
         await wizard.start()
 

--- a/permissions.py
+++ b/permissions.py
@@ -1,0 +1,104 @@
+"""Static command permission configuration.
+
+This module centralises the mapping between commands and the roles allowed to
+use them. The goal is to avoid database lookups for permissions and to make the
+rules easy to audit in version control.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Mapping
+
+import discord
+
+# Role identifiers
+ADMIN_ROLE_ID = 1_351_479_405_699_928_108
+MOD_ROLE_ID = 1_380_267_391_598_071_859
+VILTRUMITE_ROLE_ID = 1_387_453_778_445_340_872
+
+
+@dataclass(frozen=True)
+class PermissionRule:
+    role_ids: frozenset[int] = frozenset()
+    allow_boosters: bool = False
+    allow_everyone: bool = False
+
+
+ALLOW_EVERYONE = PermissionRule(allow_everyone=True)
+
+COMMAND_PERMISSION_RULES: Mapping[str, PermissionRule] = dict(
+    {
+        "test": PermissionRule(role_ids=frozenset({ADMIN_ROLE_ID})),
+        "setstatpoints": PermissionRule(role_ids=frozenset({ADMIN_ROLE_ID})),
+        "lastdate": PermissionRule(role_ids=frozenset({MOD_ROLE_ID})),
+        "setstat": PermissionRule(role_ids=frozenset({ADMIN_ROLE_ID})),
+        "addshoprole": PermissionRule(role_ids=frozenset({ADMIN_ROLE_ID})),
+        "chatrevive": PermissionRule(role_ids=frozenset({MOD_ROLE_ID})),
+        "manageprisonmember": PermissionRule(role_ids=frozenset({MOD_ROLE_ID})),
+        "manageviltrumite": PermissionRule(role_ids=frozenset({VILTRUMITE_ROLE_ID})),
+        "addcolorreactionrole": PermissionRule(role_ids=frozenset({ADMIN_ROLE_ID})),
+        "imitate": PermissionRule(
+            role_ids=frozenset({MOD_ROLE_ID}), allow_boosters=True
+        ),
+        "giveaway": PermissionRule(role_ids=frozenset({MOD_ROLE_ID})),
+        "lock": PermissionRule(role_ids=frozenset({ADMIN_ROLE_ID})),
+        "unlock": PermissionRule(role_ids=frozenset({ADMIN_ROLE_ID})),
+        "addfilterword": PermissionRule(role_ids=frozenset({MOD_ROLE_ID})),
+        "removefilterword": PermissionRule(role_ids=frozenset({MOD_ROLE_ID})),
+        "addtrigger": PermissionRule(role_ids=frozenset({MOD_ROLE_ID})),
+        "removetrigger": PermissionRule(role_ids=frozenset({MOD_ROLE_ID})),
+        "removetriggerresponse": PermissionRule(role_ids=frozenset({MOD_ROLE_ID})),
+        "setwelcomechannel": PermissionRule(role_ids=frozenset({ADMIN_ROLE_ID})),
+        "setwelcomemsg": PermissionRule(role_ids=frozenset({ADMIN_ROLE_ID})),
+        "setleavechannel": PermissionRule(role_ids=frozenset({ADMIN_ROLE_ID})),
+        "setleavemsg": PermissionRule(role_ids=frozenset({ADMIN_ROLE_ID})),
+        "setboostchannel": PermissionRule(role_ids=frozenset({ADMIN_ROLE_ID})),
+        "setboostmsg": PermissionRule(role_ids=frozenset({ADMIN_ROLE_ID})),
+        "setlogchannel": PermissionRule(role_ids=frozenset({ADMIN_ROLE_ID})),
+        "serversettings": PermissionRule(role_ids=frozenset({ADMIN_ROLE_ID})),
+        "createrole": PermissionRule(role_ids=frozenset({ADMIN_ROLE_ID})),
+        "give": PermissionRule(role_ids=frozenset({ADMIN_ROLE_ID})),
+        "remove": PermissionRule(role_ids=frozenset({ADMIN_ROLE_ID})),
+        "logmessages": PermissionRule(role_ids=frozenset({MOD_ROLE_ID})),
+        "setup-wizard": PermissionRule(role_ids=frozenset({ADMIN_ROLE_ID})),
+        "forcelowercase": PermissionRule(role_ids=frozenset({MOD_ROLE_ID})),
+        "antinukeconfig": PermissionRule(role_ids=frozenset({ADMIN_ROLE_ID})),
+        "antinukeignoreuser": PermissionRule(role_ids=frozenset({ADMIN_ROLE_ID})),
+        "antinukeignorerole": PermissionRule(role_ids=frozenset({ADMIN_ROLE_ID})),
+        "antinukelog": PermissionRule(role_ids=frozenset({ADMIN_ROLE_ID})),
+        "antinukesettings": PermissionRule(role_ids=frozenset({ADMIN_ROLE_ID})),
+    }
+)
+
+# Prefix aliases share the same rules
+COMMAND_PERMISSION_RULES = {
+    **COMMAND_PERMISSION_RULES,
+    "setupwizard": COMMAND_PERMISSION_RULES["setup-wizard"],
+}
+
+
+def get_permission_rule(command: str) -> PermissionRule:
+    return COMMAND_PERMISSION_RULES.get(command, ALLOW_EVERYONE)
+
+
+def describe_permission(guild: discord.Guild | None, command: str) -> str:
+    rule = get_permission_rule(command)
+    if rule.allow_everyone:
+        return "No specific role required"
+
+    parts: list[str] = []
+    if rule.role_ids:
+        if guild is not None:
+            role_mentions = []
+            for rid in rule.role_ids:
+                role = guild.get_role(rid)
+                role_mentions.append(role.mention if role else f"Role ID {rid}")
+        else:
+            role_mentions = [f"Role ID {rid}" for rid in rule.role_ids]
+        parts.append(" or ".join(role_mentions))
+
+    if rule.allow_boosters:
+        parts.append("Server Booster")
+
+    return " or ".join(parts) if parts else "No specific role required"


### PR DESCRIPTION
## Summary
- add a new `permissions.py` module that defines the fixed role requirements for commands and update `has_command_permission` to consult it
- rewrite admin, anti-nuke, fun, and setup wizard commands to use the static role checks, remove the old role/command configuration commands, and refresh command descriptions plus server settings output
- update documentation and command explanations to reflect the new role-based permissions

## Testing
- python -m compileall permissions.py commands utils.py

------
https://chatgpt.com/codex/tasks/task_e_68dd8c89ab808327a9a56e82d5f52ce9